### PR TITLE
Fix python 3.5 issues

### DIFF
--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -55,8 +55,8 @@ class RemoteUI:
 
         await self.cloud.run_executor(
             context.load_cert_chain,
-            self._acme.path_fullchain,
-            self._acme.path_private_key,
+            str(self._acme.path_fullchain),
+            str(self._acme.path_private_key),
         )
 
         return context


### PR DESCRIPTION
Python developers never backported one of the biggest features since python3, autospec that lands in 3.6