### PR TITLE
Add managed boolean to cloudhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ celerybeat-schedule
 *.sage.py
 
 # Environments
+bin
 .env
 .venv
 env/

--- a/hass_nabucasa/cloudhooks.py
+++ b/hass_nabucasa/cloudhooks.py
@@ -14,7 +14,7 @@ class Cloudhooks:
         self.cloud = cloud
         self.cloud.iot.register_on_connect(self.async_publish_cloudhooks)
 
-    async def async_publish_cloudhooks(self):
+    async def async_publish_cloudhooks(self) -> None:
         """Inform the Relayer of the cloudhooks that we support."""
         if not self.cloud.is_connected:
             return

--- a/hass_nabucasa/cloudhooks.py
+++ b/hass_nabucasa/cloudhooks.py
@@ -1,4 +1,6 @@
 """Manage cloud cloudhooks."""
+from typing import Dict, Any
+
 import async_timeout
 
 from . import cloud_api
@@ -24,7 +26,7 @@ class Cloudhooks:
             expect_answer=False,
         )
 
-    async def async_create(self, webhook_id, managed):
+    async def async_create(self, webhook_id: str, managed: bool) -> Dict[str, Any]:
         """Create a cloud webhook."""
         cloudhooks = self.cloud.client.cloudhooks
 
@@ -53,10 +55,9 @@ class Cloudhooks:
         await self.cloud.client.async_cloudhooks_update(cloudhooks)
 
         await self.async_publish_cloudhooks()
-
         return hook
 
-    async def async_delete(self, webhook_id):
+    async def async_delete(self, webhook_id: str) -> None:
         """Delete a cloud webhook."""
         cloudhooks = self.cloud.client.cloudhooks
 

--- a/hass_nabucasa/cloudhooks.py
+++ b/hass_nabucasa/cloudhooks.py
@@ -14,6 +14,9 @@ class Cloudhooks:
 
     async def async_publish_cloudhooks(self):
         """Inform the Relayer of the cloudhooks that we support."""
+        if not self.cloud.is_connected:
+            return
+
         cloudhooks = self.cloud.client.cloudhooks
         await self.cloud.iot.async_send_message(
             "webhook-register",
@@ -21,7 +24,7 @@ class Cloudhooks:
             expect_answer=False,
         )
 
-    async def async_create(self, webhook_id):
+    async def async_create(self, webhook_id, managed):
         """Create a cloud webhook."""
         cloudhooks = self.cloud.client.cloudhooks
 
@@ -45,10 +48,12 @@ class Cloudhooks:
             "webhook_id": webhook_id,
             "cloudhook_id": cloudhook_id,
             "cloudhook_url": cloudhook_url,
+            "managed": managed,
         }
         await self.cloud.client.async_cloudhooks_update(cloudhooks)
 
         await self.async_publish_cloudhooks()
+
         return hook
 
     async def async_delete(self, webhook_id):

--- a/tests/test_cloudhooks.py
+++ b/tests/test_cloudhooks.py
@@ -11,8 +11,10 @@ from .common import mock_coro
 @pytest.fixture
 def mock_cloudhooks(cloud_mock):
     """Mock cloudhooks class."""
-    cloud_mock.run_executor = Mock(return_value=mock_coro())
-    cloud_mock.iot = Mock(async_send_message=Mock(return_value=mock_coro()))
+    cloud_mock.run_executor = Mock(side_effect=lambda *a, **kw: mock_coro())
+    cloud_mock.iot = Mock(
+        async_send_message=Mock(side_effect=lambda *a, **kw: mock_coro())
+    )
     cloud_mock.cloudhook_create_url = "https://webhook-create.url"
     return cloudhooks.Cloudhooks(cloud_mock)
 

--- a/tests/test_cloudhooks.py
+++ b/tests/test_cloudhooks.py
@@ -31,9 +31,10 @@ async def test_enable(mock_cloudhooks, aioclient_mock):
         "webhook_id": "mock-webhook-id",
         "cloudhook_id": "mock-cloud-id",
         "cloudhook_url": "https://hooks.nabu.casa/ZXCZCXZ",
+        "managed": False,
     }
 
-    assert hook == await mock_cloudhooks.async_create("mock-webhook-id")
+    assert hook == await mock_cloudhooks.async_create("mock-webhook-id", False)
 
     assert mock_cloudhooks.cloud.client.cloudhooks == {"mock-webhook-id": hook}
 
@@ -61,3 +62,31 @@ async def test_disable(mock_cloudhooks):
     assert len(publish_calls) == 1
     assert publish_calls[0][1][0] == "webhook-register"
     assert publish_calls[0][1][1] == {"cloudhook_ids": []}
+
+
+async def test_create_without_connected(mock_cloudhooks, aioclient_mock):
+    """Test we don't publish a hook if not connected."""
+    mock_cloudhooks.cloud.is_connected = False
+    # Make sure we fail test when we send a message.
+    mock_cloudhooks.cloud.iot.async_send_message.side_effect = ValueError
+
+    aioclient_mock.post(
+        "https://webhook-create.url",
+        json={
+            "cloudhook_id": "mock-cloud-id",
+            "url": "https://hooks.nabu.casa/ZXCZCXZ",
+        },
+    )
+
+    hook = {
+        "webhook_id": "mock-webhook-id",
+        "cloudhook_id": "mock-cloud-id",
+        "cloudhook_url": "https://hooks.nabu.casa/ZXCZCXZ",
+        "managed": True,
+    }
+
+    assert hook == await mock_cloudhooks.async_create("mock-webhook-id", True)
+
+    assert mock_cloudhooks.cloud.client.cloudhooks == {"mock-webhook-id": hook}
+
+    assert len(mock_cloudhooks.cloud.iot.async_send_message.mock_calls) == 0

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -20,7 +20,7 @@ def mock_client(cloud_mock):
     # Trigger cancelled error to avoid reconnect.
     org_websession = cloud_mock.websession
     with patch("asyncio.sleep", side_effect=asyncio.CancelledError):
-        websession.ws_connect.return_value = mock_coro(client)
+        websession.ws_connect.side_effect = lambda *a, **kw: mock_coro(client)
         cloud_mock.websession = websession
         yield client
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -15,7 +15,8 @@ from .common import mock_coro, MockAcme, MockSnitun
 def ignore_context():
     """Ignore ssl context."""
     with patch(
-        "hass_nabucasa.remote.RemoteUI._create_context", return_value=mock_coro()
+        "hass_nabucasa.remote.RemoteUI._create_context",
+        side_effect=lambda *a, **lw: mock_coro(),
     ) as context:
         yield context
 


### PR DESCRIPTION
- Do not publish cloudhooks when we're not connected. They will be published when we connect.
- Keep track if a cloudhook is managed or was created by a user.