### PR TITLE
Ignore errors for when cert does not exist

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -314,8 +314,10 @@ class AcmeHandler:
         except errors.ConflictError:
             pass
         except errors.Error as err:
-            _LOGGER.error("Can't revoke certificate: %s", err)
-            raise AcmeClientError() from None
+            # Ignore errors where certificate did not exist
+            if "No such certificate" not in str(err):
+                _LOGGER.error("Can't revoke certificate: %s", err)
+                raise AcmeClientError() from None
 
         self.path_fullchain.unlink()
         self.path_private_key.unlink()


### PR DESCRIPTION
When resetting and we revoke a cert and the cert does not exist, consider the revoking a success.