### PR TITLE
Move client.async_initialize to after tokens are set

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -187,8 +187,7 @@ class Cloud:
 
         info = await self.run_executor(load_config)
 
-        await self.client.async_initialize(self)
-
+        
         if info is None:
             return
 
@@ -196,6 +195,8 @@ class Cloud:
         self.access_token = info["access_token"]
         self.refresh_token = info["refresh_token"]
 
+        await self.client.async_initialize(self)
+        
         self.run_task(self.iot.connect())
 
     async def stop(self):

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -187,7 +187,6 @@ class Cloud:
 
         info = await self.run_executor(load_config)
 
-        
         if info is None:
             return
 
@@ -196,7 +195,7 @@ class Cloud:
         self.refresh_token = info["refresh_token"]
 
         await self.client.async_initialize(self)
-        
+
         self.run_task(self.iot.connect())
 
     async def stop(self):

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -188,6 +188,7 @@ class Cloud:
         info = await self.run_executor(load_config)
 
         if info is None:
+            await self.client.async_initialize(self)
             return
 
         self.id_token = info["id_token"]


### PR DESCRIPTION
Move client.async_initialize to after tokens are set to ensure that is_logged_in property returns true.
Should fix the following Home Assistant issue:

https://github.com/home-assistant/home-assistant/issues/25499

