### PR TITLE
Update timeout to 30s

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -352,7 +352,7 @@ class AcmeHandler:
 
         # Update DNS
         try:
-            async with async_timeout.timeout(15):
+            async with async_timeout.timeout(30):
                 resp = await cloud_api.async_remote_challenge_txt(
                     self.cloud, challenge.validation
                 )

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -121,7 +121,7 @@ class RemoteUI:
 
         # Load instance data from backend
         try:
-            async with async_timeout.timeout(15):
+            async with async_timeout.timeout(30):
                 resp = await cloud_api.async_remote_register(self.cloud)
             assert resp.status == 200
         except (asyncio.TimeoutError, AssertionError):
@@ -228,7 +228,7 @@ class RemoteUI:
         # Generate session token
         aes_key, aes_iv = generate_aes_keyset()
         try:
-            async with async_timeout.timeout(15):
+            async with async_timeout.timeout(30):
                 resp = await cloud_api.async_remote_token(self.cloud, aes_key, aes_iv)
             assert resp.status == 200
         except (asyncio.TimeoutError, AssertionError):


### PR DESCRIPTION

On startup, 15sec can be to short for slow devices with many components and high load.