### PR TITLE
setup.py: bump acme version bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         "warrant==0.6.1",
         "snitun==0.20",
-        "acme==0.40.1",
+        "acme>=0.40.0,<2.0",
         "cryptography>=2.5",
         "attrs>=18.2.0",
         "pytz",


### PR DESCRIPTION
acme was released in version 1.0.

There hopefully will be no major breakage until 2.x.