### PR TITLE
Improve start

### DIFF
--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -34,7 +34,7 @@ class CloudIoT(iot_base.BaseIoT):
         self._response_handler = {}
 
         # Register start/stop
-        cloud.register_on_start(self.connect)
+        cloud.register_on_start(self.start)
         cloud.register_on_stop(self.disconnect)
 
     @property
@@ -46,6 +46,10 @@ class CloudIoT(iot_base.BaseIoT):
     def ws_server_url(self) -> str:
         """Server to connect to."""
         return self.cloud.relayer
+
+    async def start(self) -> None:
+        """Start the CloudIoT server."""
+        self.cloud.run_task(self.connect())
 
     async def async_send_message(self, handler, payload, expect_answer=True):
         """Send a message."""

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -76,9 +76,10 @@ async def test_load_backend_exists_cert(
 
     assert not remote.is_connected
     await remote.load_backend()
+    assert remote.snitun_server == "rest-remote.nabu.casa"
+    assert remote.instance_domain == "test.dui.nabu.casa"
     await asyncio.sleep(0.1)
 
-    assert remote.snitun_server == "rest-remote.nabu.casa"
     assert not acme_mock.call_issue
     assert acme_mock.init_args == (
         auth_cloud_mock,


### PR DESCRIPTION
This will make it so that we can call `cloud.start()` during `async_setup` and load all critical info during startup.