### PR TITLE
Change timeout & revert login logic

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -174,9 +174,9 @@ class Cloud:
 
     async def login(self, email: str, password: str) -> None:
         """Log a user in."""
-        with async_timeout.timeout(15):
+        async with async_timeout.timeout(30):
             await self.auth.async_login(email, password)
-        await self.start()
+        self.run_task(self.start())
 
     async def logout(self) -> None:
         """Close connection and remove all credentials."""


### PR DESCRIPTION
Update the timeout from 15s to 60s. Look like that AWS services are slower in time of cov19.

The new loggin function block to the `start` which can take 1.5 minutes because of certificates. This make the same handling as before and do that in background.