### PR TITLE
Guard for bad auth data

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -229,7 +229,7 @@ class Cloud:
                 self.client.user_message(
                     "load_auth_data",
                     "Home Assistant Cloud error",
-                    f"Unable to load authentication from {path}.",
+                    f"Unable to load authentication from {path}. [Please login again](/config/cloud)",
                 )
                 _LOGGER.warning(
                     "Error loading cloud authentication info from %s: %s", path, err

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -222,7 +222,19 @@ class Cloud:
 
             if not self.user_info_path.exists():
                 return None
-            return json.loads(self.user_info_path.read_text())
+            try:
+                return json.loads(self.user_info_path.read_text())
+            except (ValueError, OSError) as err:
+                path = self.user_info_path.relative_to(self.client.base_path)
+                self.client.user_message(
+                    "load_auth_data",
+                    "Home Assistant Cloud error",
+                    f"Unable to load authentication from {path}.",
+                )
+                _LOGGER.warning(
+                    "Error loading cloud authentication info from %s: %s", path, err
+                )
+                return None
 
         if not self.is_logged_in:
             info = await self.run_executor(load_config)

--- a/tests/common.py
+++ b/tests/common.py
@@ -44,11 +44,14 @@ class TestClient(CloudClient):
         self.mock_webhooks = []
 
         self.mock_return = []
+        self._base_path = None
 
     @property
     def base_path(self):
         """Return path to base dir."""
-        return Path(tempfile.gettempdir())
+        if self._base_path is None:
+            self._base_path = Path(tempfile.gettempdir())
+        return self._base_path
 
     @property
     def loop(self):


### PR DESCRIPTION
In some cases in some setups users are ending up with an empty auth file. This guards for it.

Fixes https://github.com/home-assistant/core/issues/34718