### PR TITLE
Add raise_for_status in cloudhook

### DIFF
--- a/hass_nabucasa/cloudhooks.py
+++ b/hass_nabucasa/cloudhooks.py
@@ -41,6 +41,7 @@ class Cloudhooks:
         with async_timeout.timeout(10):
             resp = await cloud_api.async_create_cloudhook(self.cloud)
 
+        resp.raise_for_status()
         data = await resp.json()
         cloudhook_id = data["cloudhook_id"]
         cloudhook_url = data["url"]


### PR DESCRIPTION
Only HTTP call we had that didn't check status.