### PR TITLE
Don't keep fetching snitun token when sub expired

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ async def cloud_mock(loop, aioclient_mock):
 def auth_cloud_mock(cloud_mock):
     """Return an authenticated cloud instance."""
     cloud_mock.auth.async_check_token.side_effect = mock_coro
+    cloud_mock.subscription_expired = False
     return cloud_mock
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -11,7 +11,7 @@ from hass_nabucasa.const import (
     DISPATCH_REMOTE_CONNECT,
     DISPATCH_REMOTE_DISCONNECT,
 )
-from hass_nabucasa.remote import RemoteUI
+from hass_nabucasa.remote import RemoteUI, SubscriptionExpired
 from hass_nabucasa.utils import utcnow
 
 from .common import MockAcme, MockSnitun, mock_coro
@@ -468,3 +468,11 @@ async def test_certificate_task_renew_cert(
         await remote.load_backend()
         await asyncio.sleep(0.1)
         assert acme_mock.call_issue
+
+
+async def test_refresh_token_no_sub(auth_cloud_mock):
+    """Test that we rais SubscriptionExpired if expired sub."""
+    auth_cloud_mock.subscription_expired = True
+
+    with pytest.raises(SubscriptionExpired):
+        await RemoteUI(auth_cloud_mock)._refresh_snitun_token()


### PR DESCRIPTION
When sub expired, don't try to keep fetching snitun tokens.

This is a quick fix. In the future we should redo this code to have "sub activated" and "sub deactivated" hooks.