### PR TITLE
Catch client error and some cleanups

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -296,7 +296,10 @@ class AcmeHandler:
                 self.path_fullchain.read_bytes(), default_backend()
             )
 
-        self._x509 = await self.cloud.run_executor(_load_cert)
+        try:
+            self._x509 = await self.cloud.run_executor(_load_cert)
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception loading certificate")
 
     def _revoke_certificate(self) -> None:
         """Revoke certificate."""

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -125,7 +125,7 @@ class RemoteUI:
 
         return context
 
-    async def load_backend(self) -> None:
+    async def load_backend(self) -> bool:
         """Load backend details."""
         # Load instance data from backend
         try:


### PR DESCRIPTION
This is a first pass at cleaning up the Remote UI class. 

 - Catch ClientError for when things can fail to load.
 - Catch when reading cert fails
 - Remove the breakup of load_backend and instead use an event to signal critical info is loaded to consider start finished
 - check for renewal necessary on first boot


There are still some bad situations not covered that should be addressed in future PRs:
 - load_backend now at least is retried, but maybe it should try different things based on different things that fail
 - the connect logic feels iffy. We can call connect multiple times (ie triggered by user via relayer) and it has minimal de-duplicate logic. 

Fixes #185 