### PR TITLE
Remove upper version limit for aiohttp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "cryptography>=2.8,<4.0",
         "attrs>=19.3,<20.3",
         "pytz>=2019.3",
-        "aiohttp>=3.6.1,<3.8.0",
+        "aiohttp>=3.6.1",
         "atomicwrites==1.4.0",
     ],
 )


### PR DESCRIPTION
- We want to be more compatible with Home Assistant core and not have to manage this as much.
- Home Assistant core does already pin aiohttp.