### PR TITLE
Change TTS sample rate to 24khz from 16khz

### DIFF
--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -225,7 +225,7 @@ class Voice:
             headers={
                 CONTENT_TYPE: "application/ssml+xml",
                 AUTHORIZATION: f"Bearer {self._token}",
-                "X-Microsoft-OutputFormat": "audio-16khz-128kbitrate-mono-mp3",
+                "X-Microsoft-OutputFormat": "audio-24khz-160kbitrate-mono-mp3",
             },
             data=ET.tostring(xml_body),
         ) as resp:

--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -225,7 +225,7 @@ class Voice:
             headers={
                 CONTENT_TYPE: "application/ssml+xml",
                 AUTHORIZATION: f"Bearer {self._token}",
-                "X-Microsoft-OutputFormat": "audio-24khz-160kbitrate-mono-mp3",
+                "X-Microsoft-OutputFormat": "audio-24khz-96kbitrate-mono-mp3",
             },
             data=ET.tostring(xml_body),
         ) as resp:

--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -225,7 +225,7 @@ class Voice:
             headers={
                 CONTENT_TYPE: "application/ssml+xml",
                 AUTHORIZATION: f"Bearer {self._token}",
-                "X-Microsoft-OutputFormat": "audio-24khz-96kbitrate-mono-mp3",
+                "X-Microsoft-OutputFormat": "audio-24khz-48kbitrate-mono-mp3",
             },
             data=ET.tostring(xml_body),
         ) as resp:


### PR DESCRIPTION
I noticed the audio quality of the TTS is noticeably lower than other TTS services like Google TTS or Amazon Polly.  Looking further, I found that audio files are being sampled at 16 khz instead of  24 khz.  According the [documentation](https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/language-support) the native sample rate for the neural voices is 24 khz. 

The original 128 kbps bitrate isn't supported for 24 khz.   This PR changes it to 160 kbps.   Alternately if bandwidth usage is a concern, the `audio-24khz-96kbitrate-mono-mp3` format could be selected instead.   The lower bitrate will probably still sound better due to the higher sample rate.