### PR TITLE
Logout if UserNotFound is returned

### DIFF
--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -170,7 +170,7 @@ class CognitoAuth:
 
             try:
                 await self._async_renew_access_token()
-            except Unauthenticated as err:
+            except (Unauthenticated, UserNotFound) as err:
                 _LOGGER.error("Unable to refresh token: %s", err)
 
                 self.cloud.client.user_message(


### PR DESCRIPTION
When `UserNotFound` we do not want the stored authentication data, excepting it here will call logout which will clear out that file.