### PR TITLE
Cleanups

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -49,7 +49,7 @@ class Cloud:
         self._on_start: List[Callable[[], Awaitable[None]]] = []
         self._on_stop: List[Callable[[], Awaitable[None]]] = []
         self._on_subscribe: List[Callable[[], Awaitable[None]]] = []
-        self._on_unsubscribe: List[Callable[[], Awaitable[None]]] = []
+        self._on_subscription_expire: List[Callable[[], Awaitable[None]]] = []
         self.mode = mode
         self.client = client
         self.id_token = None
@@ -149,8 +149,12 @@ class Cloud:
             for cb in self._on_subscribe:
                 self.run_task(cb)
 
-        elif not was_expired and self.subscription_expired and self._on_unsubscribe:
-            for cb in self._on_unsubscribe:
+        elif (
+            not was_expired
+            and self.subscription_expired
+            and self._on_subscription_expire
+        ):
+            for cb in self._on_subscription_expire:
                 self.run_task(cb)
 
     def register_on_start(self, on_start_cb: Callable[[], Awaitable[None]]):
@@ -165,9 +169,11 @@ class Cloud:
         """Register an async on_subscribe callback."""
         self._on_subscribe.append(on_subscribe_cb)
 
-    def register_on_unsubscribe(self, on_unsubscribe_cb: Callable[[], Awaitable[None]]):
-        """Register an async on_unsubscribe callback."""
-        self._on_unsubscribe.append(on_unsubscribe_cb)
+    def register_on_subscription_expire(
+        self, on_subscription_expire_cb: Callable[[], Awaitable[None]]
+    ):
+        """Register an async on_subscription_expire callback."""
+        self._on_subscription_expire.append(on_subscription_expire_cb)
 
     def path(self, *parts) -> Path:
         """Get config path inside cloud dir.

--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -330,6 +330,9 @@ class AcmeHandler:
             # Ignore errors where certificate has expired
             elif "Certificate is expired" in str(err):
                 pass
+            # Ignore errors where unrecognized issuer (happens dev/prod switch)
+            elif "Certificate from unrecognized issuer" in str(err):
+                pass
             else:
                 _LOGGER.error("Can't revoke certificate: %s", err)
                 raise AcmeClientError() from err

--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -197,8 +197,7 @@ class CognitoAuth:
 
         try:
             await self.cloud.run_executor(cognito.renew_access_token)
-            self.cloud.id_token = cognito.id_token
-            self.cloud.access_token = cognito.access_token
+            await self.cloud.update_token(cognito.id_token, cognito.access_token)
             await self.cloud.run_executor(self.cloud.write_user_info)
 
         except ClientError as err:

--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -148,10 +148,10 @@ class CognitoAuth:
                 await self.cloud.run_executor(
                     partial(cognito.authenticate, password=password)
                 )
-                self.cloud.id_token = cognito.id_token
-                self.cloud.access_token = cognito.access_token
-                self.cloud.refresh_token = cognito.refresh_token
-            await self.cloud.run_executor(self.cloud.write_user_info)
+                await self.cloud.run_executor(self.cloud.write_user_info)
+                await self.cloud.update_token(
+                    cognito.id_token, cognito.access_token, cognito.refresh_token
+                )
 
         except ForceChangePasswordException as err:
             raise PasswordChangeRequired() from err

--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -163,7 +163,7 @@ class CognitoAuth:
             raise UnknownError() from err
 
     async def async_check_token(self):
-        """Check that the token is valid."""
+        """Check that the token is valid and renew if necessary."""
         async with self._request_lock:
             if not self._authenticated_cognito.check_token(renew=False):
                 return

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -47,7 +47,7 @@ class CloudClient(ABC):
         """Return true if we want start a remote connection."""
 
     @abstractmethod
-    async def logged_in(self) -> None:
+    async def logged_in(self, active_subscription) -> None:
         """Called on log in."""
 
     @abstractmethod

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -47,11 +47,15 @@ class CloudClient(ABC):
         """Return true if we want start a remote connection."""
 
     @abstractmethod
-    async def logged_in(self, active_subscription) -> None:
-        """Called on log in."""
+    async def cloud_started(self) -> None:
+        """Called when cloud started with active subscription ."""
 
     @abstractmethod
-    async def cleanups(self) -> None:
+    async def cloud_stopped(self) -> None:
+        """Called when cloud is stopping."""
+
+    @abstractmethod
+    async def logout_cleanups(self) -> None:
         """Called on logout."""
 
     @abstractmethod

--- a/hass_nabucasa/google_report_state.py
+++ b/hass_nabucasa/google_report_state.py
@@ -45,7 +45,6 @@ class GoogleReportState(iot_base.BaseIoT):
         self.register_on_disconnect(self._async_on_disconnect)
 
         # Register start/stop
-        cloud.register_on_subscription_expire(self.disconnect)
         cloud.register_on_stop(self.disconnect)
 
     @property

--- a/hass_nabucasa/google_report_state.py
+++ b/hass_nabucasa/google_report_state.py
@@ -2,10 +2,13 @@
 import asyncio
 from asyncio.queues import Queue
 import logging
-from typing import Dict
+from typing import Dict, TYPE_CHECKING
 import uuid
 
 from . import iot_base
+
+if TYPE_CHECKING:
+    from . import Cloud
 
 _LOGGER = logging.getLogger(__name__)
 MAX_PENDING = 100
@@ -30,7 +33,7 @@ class GoogleReportState(iot_base.BaseIoT):
     Uses a queue to send messages.
     """
 
-    def __init__(self, cloud):
+    def __init__(self, cloud: "Cloud"):
         """Initialize Google Report State."""
         super().__init__(cloud)
         self._connect_lock = asyncio.Lock()
@@ -42,6 +45,7 @@ class GoogleReportState(iot_base.BaseIoT):
         self.register_on_disconnect(self._async_on_disconnect)
 
         # Register start/stop
+        cloud.register_on_subscription_expire(self.disconnect)
         cloud.register_on_stop(self.disconnect)
 
     @property

--- a/hass_nabucasa/google_report_state.py
+++ b/hass_nabucasa/google_report_state.py
@@ -1,4 +1,5 @@
 """Module to handle Google Report State."""
+from __future__ import annotations
 import asyncio
 from asyncio.queues import Queue
 import logging
@@ -33,7 +34,7 @@ class GoogleReportState(iot_base.BaseIoT):
     Uses a queue to send messages.
     """
 
-    def __init__(self, cloud: "Cloud"):
+    def __init__(self, cloud: Cloud):
         """Initialize Google Report State."""
         super().__init__(cloud)
         self._connect_lock = asyncio.Lock()

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -36,8 +36,6 @@ class CloudIoT(iot_base.BaseIoT):
         """Initialize the CloudIoT class."""
         super().__init__(cloud)
 
-        self.cloud = cloud
-
         # Local code waiting for a response
         self._response_handler = {}
 

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -1,4 +1,6 @@
 """Module to handle messages from Home Assistant cloud."""
+from __future__ import annotations
+
 import asyncio
 import logging
 import pprint
@@ -32,7 +34,7 @@ class ErrorMessage(Exception):
 class CloudIoT(iot_base.BaseIoT):
     """Class to manage the IoT connection."""
 
-    def __init__(self, cloud: "Cloud"):
+    def __init__(self, cloud: Cloud):
         """Initialize the CloudIoT class."""
         super().__init__(cloud)
 

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -43,8 +43,6 @@ class CloudIoT(iot_base.BaseIoT):
 
         # Register start/stop
         cloud.register_on_start(self.start)
-        cloud.register_on_subscribe(self.start)
-        cloud.register_on_subscription_expire(self.disconnect)
         cloud.register_on_stop(self.disconnect)
 
     @property

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -44,7 +44,7 @@ class CloudIoT(iot_base.BaseIoT):
         # Register start/stop
         cloud.register_on_start(self.start)
         cloud.register_on_subscribe(self.start)
-        cloud.register_on_unsubscribe(self.disconnect)
+        cloud.register_on_subscription_expire(self.disconnect)
         cloud.register_on_stop(self.disconnect)
 
     @property

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -119,6 +119,9 @@ class BaseIoT:
             if self.close_requested:
                 break
 
+            if self.require_subscription and self.cloud.subscription_expired:
+                break
+
             self.state = STATE_CONNECTING
             self.tries += 1
 

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 import logging
 import random
 import ssl
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 import aiohttp
 import async_timeout
@@ -16,6 +16,9 @@ from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
 from . import cloud_api, utils, const
 from .acme import AcmeClientError, AcmeHandler
+
+if TYPE_CHECKING:
+    from . import Cloud
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,7 +71,7 @@ class Certificate:
 class RemoteUI:
     """Class to help manage remote connections."""
 
-    def __init__(self, cloud):
+    def __init__(self, cloud: "Cloud"):
         """Initialize cloudhooks."""
         self.cloud = cloud
         self._acme = None
@@ -83,15 +86,22 @@ class RemoteUI:
 
         # Register start/stop
         cloud.register_on_start(self.start)
+        cloud.register_on_subscribe(self.start)
+        cloud.register_on_unsubscribe(self.start)
         cloud.register_on_stop(self.stop)
 
     async def start(self) -> None:
         """Start remote UI loop."""
+        if self.cloud.subscription_expired:
+            return
         self._acme_task = self.cloud.run_task(self._certificate_handler())
         await self._info_loaded.wait()
 
     async def stop(self) -> None:
         """Stop remote UI loop."""
+        if self._acme_task is None:
+            return
+
         self._acme_task.cancel()
         self._acme_task = None
 

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -1,4 +1,6 @@
 """Manage remote UI connections."""
+from __future__ import annotations
+
 import asyncio
 from contextvars import ContextVar
 from datetime import datetime, timedelta
@@ -71,7 +73,7 @@ class Certificate:
 class RemoteUI:
     """Class to help manage remote connections."""
 
-    def __init__(self, cloud: "Cloud"):
+    def __init__(self, cloud: Cloud):
         """Initialize cloudhooks."""
         self.cloud = cloud
         self._acme = None

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -87,7 +87,7 @@ class RemoteUI:
         # Register start/stop
         cloud.register_on_start(self.start)
         cloud.register_on_subscribe(self.start)
-        cloud.register_on_subscription_expire(self.start)
+        cloud.register_on_subscription_expire(self.stop)
         cloud.register_on_stop(self.stop)
 
     async def start(self) -> None:

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -86,8 +86,6 @@ class RemoteUI:
 
         # Register start/stop
         cloud.register_on_start(self.start)
-        cloud.register_on_subscribe(self.start)
-        cloud.register_on_subscription_expire(self.stop)
         cloud.register_on_stop(self.stop)
 
     async def start(self) -> None:

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -87,7 +87,7 @@ class RemoteUI:
         # Register start/stop
         cloud.register_on_start(self.start)
         cloud.register_on_subscribe(self.start)
-        cloud.register_on_unsubscribe(self.start)
+        cloud.register_on_subscription_expire(self.start)
         cloud.register_on_stop(self.stop)
 
     async def start(self) -> None:

--- a/pylintrc
+++ b/pylintrc
@@ -16,7 +16,7 @@ ignore=tests_*
 # abstract-method - with intro of async there are always methods missing
 
 [BASIC]
-good-names=id,i,j,k,ex,Run,_,fp,T
+good-names=id,i,j,k,ex,Run,_,fp,T,cb
 
 generated-members=botocore.errorfactory
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.46.0"
+VERSION = "0.47.0"
 
 setup(
     name="hass-nabucasa",

--- a/tests/common.py
+++ b/tests/common.py
@@ -60,7 +60,7 @@ class TestClient(CloudClient):
         """Return true if we want start a remote connection."""
         return self.prop_remote_autostart
 
-    async def logged_in(self):
+    async def logged_in(self, active_subscription):
         """Handle log in."""
 
     async def cleanups(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -60,10 +60,13 @@ class TestClient(CloudClient):
         """Return true if we want start a remote connection."""
         return self.prop_remote_autostart
 
-    async def logged_in(self, active_subscription):
-        """Handle log in."""
+    async def cloud_started(self):
+        """Handle cloud started."""
 
-    async def cleanups(self):
+    async def cloud_stopped(self):
+        """Handle stopping."""
+
+    async def logout_cleanups(self):
         """Need nothing to do."""
 
     def user_message(self, identifier: str, title: str, message: str) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from tests.async_mock import patch, MagicMock, PropertyMock, AsyncMock
 from aiohttp import web
 import pytest
 
+from hass_nabucasa import Cloud
+
 from .utils.aiohttp import mock_aiohttp_client
 from .common import TestClient
 
@@ -22,7 +24,7 @@ async def aioclient_mock(loop):
 @pytest.fixture
 async def cloud_mock(loop, aioclient_mock):
     """Simple cloud mock."""
-    cloud = MagicMock()
+    cloud = MagicMock(name="Mock Cloud", is_logged_in=True)
     cloud.run_task = loop.create_task
 
     def _executor(call, *args):
@@ -34,9 +36,11 @@ async def cloud_mock(loop, aioclient_mock):
     cloud.websession = aioclient_mock.create_session(loop)
     cloud.client = TestClient(loop, cloud.websession)
 
-    async def update_token(id_token, access_token):
+    async def update_token(id_token, access_token, refresh_token=None):
         cloud.id_token = id_token
         cloud.access_token = access_token
+        if refresh_token is not None:
+            cloud.refresh_token = refresh_token
 
     cloud.update_token = update_token
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,12 @@ async def cloud_mock(loop, aioclient_mock):
     cloud.websession = aioclient_mock.create_session(loop)
     cloud.client = TestClient(loop, cloud.websession)
 
+    async def update_token(id_token, access_token):
+        cloud.id_token = id_token
+        cloud.access_token = access_token
+
+    cloud.update_token = update_token
+
     yield cloud
 
     await cloud.websession.close()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,11 +10,10 @@ from hass_nabucasa import auth as auth_api
 
 
 @pytest.fixture
-def mock_cloud(loop):
+def mock_cloud(cloud_mock):
     """Mock cloud."""
-    return MagicMock(
-        is_logged_in=False, run_executor=lambda *args: loop.run_in_executor(None, *args)
-    )
+    cloud_mock.is_logged_in = False
+    return cloud_mock
 
 
 def aws_error(code, message="Unknown", operation_name="fake_operation_name"):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,6 @@
 """Tests for the tools to communicate with the cloud."""
 import asyncio
+from unittest.mock import AsyncMock
 from tests.async_mock import MagicMock, patch
 
 from botocore.exceptions import ClientError

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -81,8 +81,10 @@ async def test_initialize_loads_info(cloud_client):
     ), patch(
         "hass_nabucasa.Cloud.user_info_path",
         new_callable=PropertyMock(return_value=info_file),
+    ), patch(
+        "hass_nabucasa.auth.CognitoAuth.async_check_token"
     ):
-        await cl.start()
+        await cl.initialize()
 
     assert cl.id_token == "test-id-token"
     assert cl.access_token == "test-access-token"
@@ -113,7 +115,7 @@ async def test_initialize_loads_invalid_info(cloud_client, caplog):
         "hass_nabucasa.Cloud.user_info_path",
         new_callable=PropertyMock(return_value=info_file),
     ):
-        await cl.start()
+        await cl.initialize()
 
     assert cl.id_token is None
     assert len(cl.iot.connect.mock_calls) == 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -75,7 +75,10 @@ async def test_initialize_loads_info(cloud_client):
 
     cl._on_start.extend([cl.iot.connect, cl.remote.connect])
 
-    with patch("hass_nabucasa.Cloud._decode_claims"), patch(
+    with patch(
+        "hass_nabucasa.Cloud._decode_claims",
+        return_value={"custom:sub-exp": "2080-01-01"},
+    ), patch(
         "hass_nabucasa.Cloud.user_info_path",
         new_callable=PropertyMock(return_value=info_file),
     ):

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -55,8 +55,6 @@ def test_init_remote(auth_cloud_mock):
     RemoteUI(auth_cloud_mock)
 
     assert len(auth_cloud_mock.register_on_start.mock_calls) == 1
-    assert len(auth_cloud_mock.register_on_subscribe.mock_calls) == 1
-    assert len(auth_cloud_mock.register_on_subscription_expire.mock_calls) == 1
     assert len(auth_cloud_mock.register_on_stop.mock_calls) == 1
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -54,7 +54,10 @@ def test_init_remote(auth_cloud_mock):
     """Init remote object."""
     RemoteUI(auth_cloud_mock)
 
-    assert len(auth_cloud_mock.mock_calls) == 2
+    assert len(auth_cloud_mock.register_on_start.mock_calls) == 1
+    assert len(auth_cloud_mock.register_on_subscribe.mock_calls) == 1
+    assert len(auth_cloud_mock.register_on_subscription_expire.mock_calls) == 1
+    assert len(auth_cloud_mock.register_on_stop.mock_calls) == 1
 
 
 async def test_load_backend_exists_cert(


### PR DESCRIPTION
Couple of cleanups:
 - Manually do heartbeat so we detect faster when a connection could not be established
 - Do not try to connect to relayer/remote when no active subscription
 - connect to relayer/remote when subscription becomes active
 - Guard for remote shutting down if it was never started because no subscription

Breaking change in client API: 

`logged_in` has added `active_subscription` boolean passed in.

```python
async def logged_in(self, active_subscription) -> None:
```