### PR TITLE
Store new token

### DIFF
--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -148,10 +148,10 @@ class CognitoAuth:
                 await self.cloud.run_executor(
                     partial(cognito.authenticate, password=password)
                 )
-                await self.cloud.run_executor(self.cloud.write_user_info)
                 await self.cloud.update_token(
                     cognito.id_token, cognito.access_token, cognito.refresh_token
                 )
+                await self.cloud.run_executor(self.cloud.write_user_info)
 
         except ForceChangePasswordException as err:
             raise PasswordChangeRequired() from err

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.47.0"
+VERSION = "0.47.1"
 
 setup(
     name="hass-nabucasa",


### PR DESCRIPTION
We should first store the token on the class before writing it to disk.