### PR TITLE
Defer SNI connect to client

### DIFF
--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -60,7 +60,7 @@ class CloudClient(ABC):
 
     @abstractmethod
     async def async_cloud_connect_update(self, connect: bool) -> None:
-        """process cloud remote message to client."""
+        """Process cloud remote message to client."""
 
     @abstractmethod
     async def async_alexa_message(self, payload: Dict[Any, Any]) -> Dict[Any, Any]:

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -59,6 +59,10 @@ class CloudClient(ABC):
         """Called on logout."""
 
     @abstractmethod
+    async def async_cloud_connect_update(self, connect: bool) -> None:
+        """process cloud remote message to client."""
+
+    @abstractmethod
     async def async_alexa_message(self, payload: Dict[Any, Any]) -> Dict[Any, Any]:
         """process cloud alexa message to client."""
 

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -172,7 +172,6 @@ async def async_handle_cloud(cloud, payload):
 @HANDLERS.register("remote_sni")
 async def async_handle_remote_sni(cloud: Cloud, payload):
     """Handle remote UI requests for cloud."""
-    # caller_ip = payload["ip_address"]
     await cloud.client.async_cloud_connect_update(True)
     return {"server": cloud.remote.snitun_server}
 

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -170,11 +170,10 @@ async def async_handle_cloud(cloud, payload):
 
 
 @HANDLERS.register("remote_sni")
-async def async_handle_remote_sni(cloud, payload):
+async def async_handle_remote_sni(cloud: Cloud, payload):
     """Handle remote UI requests for cloud."""
-    caller_ip = payload["ip_address"]
-
-    await cloud.remote.handle_connection_requests(caller_ip)
+    # caller_ip = payload["ip_address"]
+    await cloud.client.async_cloud_connect_update(True)
     return {"server": cloud.remote.snitun_server}
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -80,7 +80,7 @@ class TestClient(CloudClient):
         self.mock_dispatcher.append((identifier, data))
 
     async def async_cloud_connect_update(self, connect: bool) -> None:
-        """process cloud remote message to client."""
+        """Process cloud remote message to client."""
         self.pref_should_connect = connect
 
     async def async_alexa_message(self, payload):

--- a/tests/common.py
+++ b/tests/common.py
@@ -28,6 +28,8 @@ class TestClient(CloudClient):
         self.mock_return = []
         self._base_path = None
 
+        self.pref_should_connect = False
+
     @property
     def base_path(self):
         """Return path to base dir."""
@@ -76,6 +78,10 @@ class TestClient(CloudClient):
     def dispatcher_message(self, identifier: str, data: Any = None) -> None:
         """Send data to dispatcher."""
         self.mock_dispatcher.append((identifier, data))
+
+    async def async_cloud_connect_update(self, connect: bool) -> None:
+        """process cloud remote message to client."""
+        self.pref_should_connect = connect
 
     async def async_alexa_message(self, payload):
         """process cloud alexa message to client."""

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -149,12 +149,11 @@ async def test_handler_webhook(cloud_mock):
 
 async def test_handler_remote_sni(cloud_mock):
     """Test handler Webhook."""
-    cloud_mock.remote.handle_connection_requests = AsyncMock()
+    assert not cloud_mock.client.pref_should_connect
     cloud_mock.remote.snitun_server = "1.1.1.1"
     resp = await iot.async_handle_remote_sni(cloud_mock, {"ip_address": "8.8.8.8"})
 
-    assert cloud_mock.remote.handle_connection_requests.called
-    assert cloud_mock.remote.handle_connection_requests.mock_calls[0][1][0] == "8.8.8.8"
+    assert cloud_mock.client.pref_should_connect
     assert resp == {"server": "1.1.1.1"}
 
 


### PR DESCRIPTION
Defer the SNI connect request to the client instead of handling it internally, so we can reflect it correctly inside Home Assistant.