### PR TITLE
Do not block at startup

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -291,6 +291,7 @@ class Cloud:
         self.started = True
         await self._start()
         await gather_callbacks(_LOGGER, "on_initialized", self._on_initialized)
+        self._init_task = None
 
     async def _start(self):
         """Start the cloud component."""

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -12,7 +12,7 @@ import async_timeout
 from atomicwrites import atomic_write
 from jose import jwt
 
-from .auth import CognitoAuth
+from .auth import CloudError, CognitoAuth
 from .client import CloudClient
 from .cloudhooks import Cloudhooks
 from .const import CONFIG_DIR, MODE_DEV, SERVERS, STATE_CONNECTED
@@ -273,9 +273,8 @@ class Cloud:
         """Finish initializing the cloud component (load auth and maybe start)."""
         try:
             await self.auth.async_check_token()
-        except auth.CloudError:
+        except CloudError:
             _LOGGER.debug("Failed to check cloud token", exc_info=True)
-            pass
 
         if self.subscription_expired:
             self.started = False

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -84,8 +84,6 @@ class RemoteUI:
         self._acme_task = None
         self._token = None
 
-        self._info_loaded = asyncio.Event()
-
         # Register start/stop
         cloud.register_on_start(self.start)
         cloud.register_on_stop(self.stop)
@@ -95,7 +93,6 @@ class RemoteUI:
         if self.cloud.subscription_expired:
             return
         self._acme_task = self.cloud.run_task(self._certificate_handler())
-        await self._info_loaded.wait()
 
     async def stop(self) -> None:
         """Stop remote UI loop."""
@@ -180,8 +177,6 @@ class RemoteUI:
         if ca_domain and ca_domain != domain:
             _LOGGER.warning("Invalid certificate found: %s", ca_domain)
             await self._acme.reset_acme()
-
-        self._info_loaded.set()
 
         should_create_cert = not self._acme.certificate_available
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -47,7 +47,10 @@ def test_constructor_loads_info_from_constant(cloud_client):
 
 
 async def test_initialize_loads_info(cloud_client):
-    """Test initialize will load info from config file."""
+    """Test initialize will load info from config file.
+
+    Also tests that on_initialized callbacks are called when initialization finishes.
+    """
     cl = cloud.Cloud(cloud_client, cloud.MODE_DEV)
 
     assert len(cl._on_start) == 2
@@ -79,7 +82,8 @@ async def test_initialize_loads_info(cloud_client):
     async def start_done():
         start_done_event.set()
 
-    cl._on_start.extend([cl.iot.connect, cl.remote.connect, start_done])
+    cl._on_start.extend([cl.iot.connect, cl.remote.connect])
+    cl.register_on_initialized(start_done)
 
     with patch(
         "hass_nabucasa.Cloud._decode_claims",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -75,6 +75,7 @@ async def test_initialize_loads_info(cloud_client):
     cl.remote.connect = AsyncMock()
 
     start_done_event = asyncio.Event()
+
     async def start_done():
         start_done_event.set()
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -86,6 +86,7 @@ async def test_load_backend_exists_cert(
 
     assert not remote.is_connected
     await remote.start()
+    await asyncio.sleep(0.1)
     assert remote.snitun_server == "rest-remote.nabu.casa"
     assert remote.instance_domain == "test.dui.nabu.casa"
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -86,7 +86,7 @@ async def test_load_backend_exists_cert(
 
     assert not remote.is_connected
     await remote.start()
-    await asyncio.sleep(0.1)
+    await remote._info_loaded.wait()
     assert remote.snitun_server == "rest-remote.nabu.casa"
     assert remote.instance_domain == "test.dui.nabu.casa"
 


### PR DESCRIPTION
`Cloud.initialize` refreshes the access token (if needed) and waits until `RemoteUI` is connected, which will block for a very long time if we're not connected to the network.

This changes such that we return before the potentially long-running network access to allow HA core to initialize cloud when there's no network, access token refresh and remote connection is handed off to a task.

To synchronize completion of initialization, it's possible to register `on_initialized` callbacks.