### PR TITLE
Make ACME reset more error tolerant

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -404,10 +404,10 @@ class AcmeHandler:
             await self.cloud.run_executor(self._revoke_certificate)
             await self.cloud.run_executor(self._deactivate_account)
         finally:
-            await self.cloud.run_executor(self._remove_files)
             self._acme_client = None
             self._account_jwk = None
             self._x509 = None
+            await self.cloud.run_executor(self._remove_files)
 
     async def hardening_files(self) -> None:
         """Control permission on files."""


### PR DESCRIPTION
Make ACME reset more error tolerant:
  - Don't reraise unknown ACME errors, just log them
  - Make sure we always unlink ACME files