### PR TITLE
Remove asynctest

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,4 +1,3 @@
-asynctest==0.13.0
 flake8==4.0.1
 pylint==2.12.2
 pytest==6.2.5

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,9 +1,0 @@
-"""Mock utilities that are async aware."""
-import sys
-
-if sys.version_info[:2] < (3, 8):
-    from asynctest.mock import *  # noqa
-
-    AsyncMock = CoroutineMock  # noqa: F405
-else:
-    from unittest.mock import *  # noqa

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ import asyncio
 from pathlib import Path
 import tempfile
 from typing import Any
-from tests.async_mock import Mock
+from unittest.mock import Mock
 
 from hass_nabucasa.client import CloudClient
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Set up some common test helper things."""
 import asyncio
 import logging
-from tests.async_mock import patch, MagicMock, PropertyMock, AsyncMock
+from unittest.mock import patch, MagicMock, PropertyMock, AsyncMock
 
 from aiohttp import web
 import pytest

--- a/tests/test_account_link.py
+++ b/tests/test_account_link.py
@@ -1,6 +1,6 @@
 """Test Account Linking tools."""
 import asyncio
-from tests.async_mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock
 
 from aiohttp import web
 import pytest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,6 @@
 """Tests for the tools to communicate with the cloud."""
 import asyncio
-from unittest.mock import AsyncMock
-from tests.async_mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from botocore.exceptions import ClientError
 import pytest

--- a/tests/test_cloudhooks.py
+++ b/tests/test_cloudhooks.py
@@ -1,5 +1,5 @@
 """Test cloud cloudhooks."""
-from tests.async_mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 

--- a/tests/test_google_report_state.py
+++ b/tests/test_google_report_state.py
@@ -1,6 +1,6 @@
 """Tests for Google Report State."""
 import asyncio
-from tests.async_mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from hass_nabucasa import iot_base
 from hass_nabucasa.google_report_state import GoogleReportState, ErrorResponse

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,7 @@
 """Test the cloud component."""
 import asyncio
 import json
-from tests.async_mock import AsyncMock, patch, MagicMock, Mock, PropertyMock
+from unittest.mock import AsyncMock, patch, MagicMock, Mock, PropertyMock
 
 import hass_nabucasa as cloud
 from hass_nabucasa.utils import utcnow

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -1,12 +1,11 @@
 """Test the cloud.iot module."""
 import asyncio
+from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 from aiohttp import WSMsgType
 import pytest
 
 from hass_nabucasa import iot, iot_base
-
-from tests.async_mock import AsyncMock, MagicMock, Mock, call, patch
 
 
 @pytest.fixture

--- a/tests/test_iot_base.py
+++ b/tests/test_iot_base.py
@@ -1,6 +1,6 @@
 """Test the cloud.iot_base module."""
 import asyncio
-from tests.async_mock import AsyncMock, patch, MagicMock, Mock
+from unittest.mock import AsyncMock, patch, MagicMock, Mock
 
 from aiohttp import WSMsgType, client_exceptions
 import pytest

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -1,7 +1,7 @@
 """Test remote sni handler."""
 import asyncio
 from datetime import timedelta
-from tests.async_mock import patch, Mock
+from unittest.mock import patch
 
 import pytest
 


### PR DESCRIPTION
- Since we require Python 3.8+ we no longer need asynctest.
- Remove the async test util that selected asynctest for Python versions below 3.8.
- Import from unittest.mock.