### PR TITLE
Increase flake8 scope

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -84,7 +84,7 @@ class TestClient(CloudClient):
         self.pref_should_connect = connect
 
     async def async_alexa_message(self, payload):
-        """process cloud alexa message to client."""
+        """Process cloud alexa message to client."""
         self.mock_alexa.append(payload)
         return self.mock_return.pop()
 
@@ -120,6 +120,7 @@ class MockAcme:
         self.fingerprint = None
 
     def set_false(self):
+        """Set certificate as not valid."""
         self.is_valid = False
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,6 @@ from unittest.mock import patch, MagicMock, PropertyMock, AsyncMock
 from aiohttp import web
 import pytest
 
-from hass_nabucasa import Cloud
-
 from .utils.aiohttp import mock_aiohttp_client
 from .common import TestClient
 
@@ -23,7 +21,7 @@ async def aioclient_mock(loop):
 
 @pytest.fixture
 async def cloud_mock(loop, aioclient_mock):
-    """Simple cloud mock."""
+    """Yield a simple cloud mock."""
     cloud = MagicMock(name="Mock Cloud", is_logged_in=True)
     cloud.run_task = loop.create_task
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -191,6 +191,7 @@ async def test_async_setup(cloud_mock):
 
 
 async def test_guard_no_login_authenticated_cognito():
+    """Test that not authenticated cognito login raises."""
     with pytest.raises(auth_api.Unauthenticated):
         auth_api.CognitoAuth(MagicMock(access_token=None))._authenticated_cognito
 

--- a/tests/test_google_report_state.py
+++ b/tests/test_google_report_state.py
@@ -40,7 +40,7 @@ async def test_send_messages(loop, ws_server):
     server_msgs = []
 
     async def handle_server_msg(msg):
-        """handle a server msg."""
+        """Handle a server msg."""
         incoming = msg.json()
         server_msgs.append(incoming["payload"])
 
@@ -85,7 +85,7 @@ async def test_max_queue_message(loop, ws_server):
     server_msgs = []
 
     async def handle_server_msg(msg):
-        """handle a server msg."""
+        """Handle a server msg."""
         incoming = msg.json()
         server_msgs.append(incoming["payload"])
         return {"msgid": incoming["msgid"], "payload": incoming["payload"]["hello"]}

--- a/tests/utils/aiohttp.py
+++ b/tests/utils/aiohttp.py
@@ -1,5 +1,4 @@
 """Aiohttp test utils."""
-import asyncio
 from contextlib import contextmanager
 import json as _json
 import re

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,5 @@ basepython = python3
 ignore_errors = True
 commands =
     black --check hass_nabucasa tests setup.py
-    flake8 hass_nabucasa
+    flake8 hass_nabucasa setup.py tests
     pylint --rcfile pylintrc hass_nabucasa


### PR DESCRIPTION
- Run flake8 on all Python modules including tests.
- Flake8 is not in the way when writing tests so there's no downside to keeping the tests tidy by using this linter.