### PR TITLE
Handle more close messages

### DIFF
--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -184,7 +184,7 @@ class BaseIoT:
                     await client.ping()
                     continue
 
-                if msg.type in (WSMsgType.CLOSED, WSMsgType.CLOSING):
+                if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.CLOSING):
                     break
 
                 if msg.type == WSMsgType.ERROR:


### PR DESCRIPTION
Also handle `WSMsgType.CLOSE` as closing.

Fixes message

```
(MainThread) [hass_nabucasa.iot] Connection closed: Received non-Text message: 8
```