### PR TITLE
Remove pytz dependency

### DIFF
--- a/hass_nabucasa/utils.py
+++ b/hass_nabucasa/utils.py
@@ -5,11 +5,9 @@ import logging
 import ssl
 from typing import Awaitable, Callable, List, Optional, TypeVar
 
-import pytz
-
 CALLABLE_T = TypeVar("CALLABLE_T", bound=Callable)  # noqa pylint: disable=invalid-name
 DATE_STR_FORMAT = "%Y-%m-%d"
-UTC = pytz.utc
+UTC = dt.timezone.utc
 
 
 def utcnow() -> dt.datetime:
@@ -19,7 +17,7 @@ def utcnow() -> dt.datetime:
 
 def utc_from_timestamp(timestamp: float) -> dt.datetime:
     """Return a UTC time from a timestamp."""
-    return UTC.localize(dt.datetime.utcfromtimestamp(timestamp))
+    return dt.datetime.utcfromtimestamp(timestamp).replace(tzinfo=UTC)
 
 
 def parse_date(dt_str: str) -> Optional[dt.date]:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "acme==1.23.0",
         "cryptography>=2.8,<37.0",
         "attrs>=19.3",
-        "pytz>=2019.3",
         "aiohttp>=3.6.1",
         "atomicwrites==1.4.0",
     ],


### PR DESCRIPTION
It's not needed for these use cases in Python >= 3.6.

https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html#creating-an-aware-datetime-localizing-datetimes