### PR TITLE
Remove not used cryptography backend parameter

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -13,7 +13,6 @@ import async_timeout
 from atomicwrites import atomic_write
 import attr
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
@@ -146,16 +145,12 @@ class AcmeHandler:
         if self.path_account_key.exists():
             _LOGGER.debug("Load account keyfile: %s", self.path_account_key)
             pem = self.path_account_key.read_bytes()
-            key = serialization.load_pem_private_key(
-                pem, password=None, backend=default_backend()
-            )
+            key = serialization.load_pem_private_key(pem, password=None)
 
         else:
             _LOGGER.debug("Create new RSA keyfile: %s", self.path_account_key)
             key = rsa.generate_private_key(
-                public_exponent=65537,
-                key_size=ACCOUNT_KEY_SIZE,
-                backend=default_backend(),
+                public_exponent=65537, key_size=ACCOUNT_KEY_SIZE
             )
 
             # Store it to file
@@ -300,9 +295,7 @@ class AcmeHandler:
 
         def _load_cert():
             """Load certificate in a thread."""
-            return x509.load_pem_x509_certificate(
-                self.path_fullchain.read_bytes(), default_backend()
-            )
+            return x509.load_pem_x509_certificate(self.path_fullchain.read_bytes())
 
         try:
             self._x509 = await self.cloud.run_executor(_load_cert)


### PR DESCRIPTION
The backend parameter was deprecated in version 36.0.0 of cryptography but I missed that. The changelog has a bad link.

- https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#3600---2021-11-21
- https://github.com/pyca/cryptography/blob/df06889f348d7c3b7e9c35e4e5a1b1480f0b2c5a/src/cryptography/hazmat/primitives/serialization/base.py#L15-L22
- https://github.com/pyca/cryptography/blob/df06889f348d7c3b7e9c35e4e5a1b1480f0b2c5a/src/cryptography/hazmat/primitives/asymmetric/rsa.py#L145-L153
- https://github.com/pyca/cryptography/blob/df06889f348d7c3b7e9c35e4e5a1b1480f0b2c5a/src/cryptography/x509/base.py#L527-L531