### PR TITLE
Remove upperbound cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "pycognito==2022.8.0",
         "snitun==0.31.0",
         "acme==1.29.0",
-        "cryptography>=2.8,<38.0",
+        "cryptography>=2.8",
         "attrs>=19.3",
         "aiohttp>=3.6.1",
         "atomicwrites-homeassistant==1.4.1",


### PR DESCRIPTION
Instead of trying to keep our upperbound in sync with HA, let's keep HA deciding on what to use (which they do in constraints).