### PR TITLE
Add missing path

### DIFF
--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -56,7 +56,7 @@ class CloudIoT(iot_base.BaseIoT):
     @property
     def ws_server_url(self) -> str:
         """Server to connect to."""
-        return f"wss://{self.cloud.relayer_server}"
+        return f"wss://{self.cloud.relayer_server}/websocket"
 
     async def start(self) -> None:
         """Start the CloudIoT server."""


### PR DESCRIPTION
Add missing `/websocket` path to `CloudIoT.ws_server_url`