### PR TITLE
Cleanup of pylint config

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -6,8 +6,6 @@ ignore=tests_*
 # locally-disabled - it spams too much
 # duplicate-code - unavoidable
 # cyclic-import - doesn't test if both import on load
-# abstract-class-little-used - prevents from setting right foundation
-# abstract-class-not-used - is flaky, should not show up but does
 # unused-argument - generic callbacks and setup methods create a lot of warnings
 # global-statement - used for the on-demand requirement installation
 # redefined-variable-type - this is Python, we're duck typing!
@@ -21,15 +19,12 @@ good-names=id,i,j,k,ex,Run,_,fp,T,cb
 generated-members=botocore.errorfactory
 
 disable=
-  abstract-class-little-used,
-  abstract-class-not-used,
   abstract-method,
   cyclic-import,
   duplicate-code,
   global-statement,
   locally-disabled,
   not-context-manager,
-  redefined-variable-type,
   too-few-public-methods,
   too-many-arguments,
   too-many-branches,
@@ -42,9 +37,7 @@ disable=
   unused-argument,
   missing-docstring,
   line-too-long,
-  bad-continuation,
   too-few-public-methods,
-  no-self-use,
   too-many-locals,
   too-many-branches
 


### PR DESCRIPTION
From previous runs:
```
************* Module pylintrc
pylintrc:1:0: R0022: Useless option value for '--disable', 'abstract-class-little-used' was removed from pylint, see https://pylint.pycqa.org/en/latest/whatsnew/1/1.4.html#what-s-new-in-pylint-1-4-3. (useless-option-value)
pylintrc:1:0: R0022: Useless option value for '--disable', 'abstract-class-not-used' was removed from pylint, see https://pylint.pycqa.org/en/latest/whatsnew/1/1.4.html#what-s-new-in-pylint-1-4-3. (useless-option-value)
pylintrc:1:0: R0022: Useless option value for '--disable', 'bad-continuation' was removed from pylint, see https://github.com/PyCQA/pylint/pull/3571. (useless-option-value)
pylintrc:1:0: R0022: Useless option value for '--disable', 'no-self-use' was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers. (useless-option-value)
pylintrc:1:0: W0012: Unknown option value for '--disable', expected a valid pylint message and got 'redefined-variable-type' (unknown-option-value)
```