### PR TITLE
TTS to accept raw & STT to use async generators

### DIFF
--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-import logging
 from typing import TYPE_CHECKING, AsyncIterable
 import xml.etree.ElementTree as ET
 
@@ -15,8 +14,6 @@ from .utils import utc_from_timestamp, utcnow
 
 if TYPE_CHECKING:
     from . import Cloud
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class VoiceError(Exception):
@@ -410,7 +407,4 @@ class Voice:
         ) as resp:
             if resp.status != 200:
                 raise VoiceReturnError()
-            resp = await resp.read()
-            with open("/tmp/azure.wav", "wb") as file:
-                file.write(resp)
-            return resp
+            return await resp.read()

--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING, AsyncGenerator
+from typing import TYPE_CHECKING, AsyncIterable
 import xml.etree.ElementTree as ET
 
 from aiohttp.hdrs import ACCEPT, AUTHORIZATION, CONTENT_TYPE
@@ -345,7 +345,7 @@ class Voice:
         self._valid = utc_from_timestamp(float(data["valid"]))
 
     async def process_stt(
-        self, stream: AsyncGenerator[bytes], content: str, language: str
+        self, stream: AsyncIterable[bytes], content: str, language: str
     ) -> STTResponse:
         """Stream Audio to Azure congnitive instance."""
         if not self._validate_token():

--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, AsyncGenerator
 import xml.etree.ElementTree as ET
 
-import aiohttp
 from aiohttp.hdrs import ACCEPT, AUTHORIZATION, CONTENT_TYPE
 import attr
 
@@ -339,7 +338,7 @@ class Voice:
         self._valid = utc_from_timestamp(float(data["valid"]))
 
     async def process_stt(
-        self, stream: aiohttp.StreamReader, content: str, language: str
+        self, stream: AsyncGenerator[bytes], content: str, language: str
     ) -> STTResponse:
         """Stream Audio to Azure congnitive instance."""
         if not self._validate_token():

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -74,7 +74,12 @@ async def test_process_tts(auth_cloud_mock, aioclient_mock):
         content=b"My sound",
     )
     result = await voice_api.process_tts(
-        "Text for Saying", "en-US", voice.Gender.FEMALE
+        "Text for Saying", "en-US", voice.Gender.FEMALE, voice.AudioOutput.MP3
     )
 
     assert result == b"My sound"
+    assert aioclient_mock.mock_calls[1][3] == {
+        "Authorization": "Bearer test-key",
+        "Content-Type": "application/ssml+xml",
+        "X-Microsoft-OutputFormat": "audio-24khz-48kbitrate-mono-mp3",
+    }


### PR DESCRIPTION
2 small changes for the voice infra:

 - aiohttp supports async generators for content. We're moving to that data format in HA
 - allow returning raw data to skip MP3 decoding for devices that do not support it