### PR TITLE
Allow profanity in Speech-to-Text

### DIFF
--- a/hass_nabucasa/voice.py
+++ b/hass_nabucasa/voice.py
@@ -350,7 +350,7 @@ class Voice:
 
         # Send request
         async with self.cloud.websession.post(
-            f"{self._endpoint_stt}?language={language}",
+            f"{self._endpoint_stt}?language={language}&profanity=raw",
             headers={
                 CONTENT_TYPE: content,
                 AUTHORIZATION: f"Bearer {self._token}",


### PR DESCRIPTION
Stop Speech-to-Text from censoring profanity.

https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/rest-speech-to-text-short#query-parameters