### PR TITLE
Drop python 3.8 and 3.9

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,7 @@
 {
   "name": "Hass-NabuCasa Dev",
   "context": ".",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.8",
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.10",
   "postCreateCommand": "pip3 install -r requirements_tests.txt",
   "postStartCommand": "pip3 install -e .",
   "containerUser": "vscode",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,6 @@ setup(
         "Topic :: Internet :: Proxy Servers",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Development Status :: 5 - Production/Stable",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
@@ -29,7 +27,7 @@ setup(
     zip_safe=False,
     platforms="any",
     packages=["hass_nabucasa"],
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     install_requires=[
         "pycognito==2022.12.0",
         "snitun==0.35.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py38, py39, py310, py311, lint
+envlist = py310, py311, lint
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.8: py38, lint
-    3.9: py39
-    3.10: py310
+    3.10: py310, lint
     3.11: py311
 
 [testenv]


### PR DESCRIPTION
We do not expect this to be used outside of the `cloud` integration inside Home Assistant.
Home Assistant requires python 3.10 now, so we do not need to keep 3.8 and 3.9 around.