### PR TITLE
Remove setting patch for dependencies

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,9 +6,6 @@ categories:
     labels:
       - "dependencies"
 version-resolver:
-  patch:
-    labels:
-      - 'dependencies'
   default: minor
 change-template: '- #$NUMBER $TITLE @$AUTHOR'
 sort-direction: ascending


### PR DESCRIPTION
This is too sticky, if _any_ dependency is there it will only be patch, not only if all are dependency