### PR TITLE
Add cloud_connected and cloud_disconnected methods to CloudClient

### DIFF
--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -49,8 +49,12 @@ class CloudClient(ABC):
         """Return true if we want start a remote connection."""
 
     @abstractmethod
+    async def cloud_connected(self) -> None:
+        """Called when cloud connected."""
+
+    @abstractmethod
     async def cloud_started(self) -> None:
-        """Called when cloud started with active subscription ."""
+        """Called when cloud started with active subscription."""
 
     @abstractmethod
     async def cloud_stopped(self) -> None:

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -53,6 +53,10 @@ class CloudClient(ABC):
         """Called when cloud connected."""
 
     @abstractmethod
+    async def cloud_disconnected(self) -> None:
+        """Called when cloud disconnected."""
+
+    @abstractmethod
     async def cloud_started(self) -> None:
         """Called when cloud started with active subscription."""
 

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -139,10 +139,12 @@ class BaseIoT:
                 # Still adding it here to make sure we can always reconnect
                 self._logger.exception("Unexpected error")
 
-            if self.state == STATE_CONNECTED and self._on_disconnect:
-                await gather_callbacks(
-                    self._logger, "on_disconnect", self._on_disconnect
-                )
+            if self.state == STATE_CONNECTED:
+                await self.cloud.client.cloud_disconnected()
+                if self._on_disconnect:
+                    await gather_callbacks(
+                        self._logger, "on_disconnect", self._on_disconnect
+                    )
 
             if self.close_requested:
                 break

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -306,5 +306,6 @@ class BaseIoT:
         self.state = STATE_CONNECTED
         self._logger.info("Connected")
 
+        await self.cloud.client.cloud_connected()
         if self._on_connect:
             await gather_callbacks(self._logger, "on_connect", self._on_connect)

--- a/tests/common.py
+++ b/tests/common.py
@@ -68,6 +68,9 @@ class MockClient(CloudClient):
     async def cloud_connected(self):
         """Handle cloud connected."""
 
+    async def cloud_disconnected(self):
+        """Handle cloud disconnected."""
+
     async def cloud_started(self):
         """Handle cloud started."""
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,11 +10,11 @@ from unittest.mock import Mock
 from hass_nabucasa.client import CloudClient
 
 
-class TestClient(CloudClient):
+class MockClient(CloudClient):
     """Interface class for Home Assistant."""
 
     def __init__(self, loop, websession):
-        """Initialize TestClient."""
+        """Initialize MockClient."""
         self._loop = loop
         self._websession = websession
         self._cloudhooks = {}

--- a/tests/common.py
+++ b/tests/common.py
@@ -65,6 +65,9 @@ class TestClient(CloudClient):
         """Return true if we want start a remote connection."""
         return self.prop_remote_autostart
 
+    async def cloud_connected(self):
+        """Handle cloud connected."""
+
     async def cloud_started(self):
         """Handle cloud started."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from aiohttp import web
 import pytest
 
 from .utils.aiohttp import mock_aiohttp_client
-from .common import TestClient
+from .common import MockClient
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -34,7 +34,7 @@ async def cloud_mock(event_loop, aioclient_mock):
     cloud.run_executor = _executor
 
     cloud.websession = aioclient_mock.create_session(loop)
-    cloud.client = TestClient(loop, cloud.websession)
+    cloud.client = MockClient(loop, cloud.websession)
 
     async def update_token(id_token, access_token, refresh_token=None):
         cloud.id_token = id_token

--- a/tests/test_google_report_state.py
+++ b/tests/test_google_report_state.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from hass_nabucasa import iot_base
 from hass_nabucasa.google_report_state import GoogleReportState, ErrorResponse
 
+from .common import MockClient
 
 async def create_grs(loop, ws_server, server_msg_handler) -> GoogleReportState:
     """Create a grs instance."""
@@ -15,6 +16,7 @@ async def create_grs(loop, ws_server, server_msg_handler) -> GoogleReportState:
         remotestate_server="mock-report-state-url.com",
         auth=Mock(async_check_token=AsyncMock()),
         websession=Mock(ws_connect=AsyncMock(return_value=client)),
+        client=Mock(spec_set=MockClient)
     )
     return GoogleReportState(mock_cloud)
 

--- a/tests/test_google_report_state.py
+++ b/tests/test_google_report_state.py
@@ -7,6 +7,7 @@ from hass_nabucasa.google_report_state import GoogleReportState, ErrorResponse
 
 from .common import MockClient
 
+
 async def create_grs(loop, ws_server, server_msg_handler) -> GoogleReportState:
     """Create a grs instance."""
     client = await ws_server(server_msg_handler)
@@ -16,7 +17,7 @@ async def create_grs(loop, ws_server, server_msg_handler) -> GoogleReportState:
         remotestate_server="mock-report-state-url.com",
         auth=Mock(async_check_token=AsyncMock()),
         websession=Mock(ws_connect=AsyncMock(return_value=client)),
-        client=Mock(spec_set=MockClient)
+        client=Mock(spec_set=MockClient),
     )
     return GoogleReportState(mock_cloud)
 


### PR DESCRIPTION
The cloud client needs to be informed about connection to the cloud.
This is currently solved by registering it manually: https://github.com/home-assistant/core/blob/8d823359c3b2f0ff3a1a3f6a57cb080ab849f1ff/homeassistant/components/cloud/__init__.py#L244

This PR adds a a method to the abstract `CloudClient` instead to be consistent with the already existing callbacks which are called when the cloud connection is started or stopped.

In addition to the `cloud_connected` method, this PR also adds a method which is called when disconnected from the cloud.