### PR TITLE
Use servicehandlers server for voice

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -51,7 +51,7 @@ class Cloud:
         remote_sni_server: str | None = None,
         remotestate_server: str | None = None,
         thingtalk_server: str | None = None,
-        voice_server: str | None = None,
+        servicehandlers_server: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Create an instance of Cloud."""
@@ -90,7 +90,7 @@ class Cloud:
             self.remote_sni_server = remote_sni_server
             self.remotestate_server = remotestate_server
             self.thingtalk_server = thingtalk_server
-            self.voice_server = voice_server
+            self.servicehandlers_server = servicehandlers_server
             return
 
         _values = DEFAULT_VALUES[mode]
@@ -110,7 +110,7 @@ class Cloud:
         self.remote_sni_server = _servers["remote_sni"]
         self.remotestate_server = _servers["remotestate"]
         self.thingtalk_server = _servers["thingtalk"]
-        self.voice_server = _servers["voice"]
+        self.servicehandlers_server = _servers["servicehandlers"]
 
     @property
     def is_logged_in(self) -> bool:

--- a/hass_nabucasa/cloud_api.py
+++ b/hass_nabucasa/cloud_api.py
@@ -121,7 +121,7 @@ async def async_alexa_access_token(cloud: Cloud) -> ClientResponse:
 @_log_response
 async def async_voice_connection_details(cloud: Cloud) -> ClientResponse:
     """Return connection details for voice service."""
-    url = f"https://{cloud.voice_server}/connection_details"
+    url = f"https://{cloud.servicehandlers_server}/voice/connection_details"
     return await cloud.websession.get(url, headers={AUTHORIZATION: cloud.id_token})
 
 

--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -27,8 +27,8 @@ DEFAULT_SERVERS: dict[str, dict[str, str]] = {
         "relayer": "cloud.nabucasa.com",
         "remote_sni": "remote-sni-api.nabucasa.com",
         "remotestate": "remotestate.nabucasa.com",
+        "servicehandlers": "servicehandlers.nabucasa.com",
         "thingtalk": "thingtalk-api.nabucasa.com",
-        "voice": "voice-api.nabucasa.com",
     },
     "development": {},
 }

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -102,9 +102,9 @@ async def test_get_access_token(auth_cloud_mock, aioclient_mock):
 
 async def test_voice_connection_details(auth_cloud_mock, aioclient_mock):
     """Test creating a cloudhook."""
-    aioclient_mock.get("https://example.com/connection_details")
+    aioclient_mock.get("https://example.com/voice/connection_details")
     auth_cloud_mock.id_token = "mock-id-token"
-    auth_cloud_mock.voice_server = "example.com"
+    auth_cloud_mock.servicehandlers_server = "example.com"
 
     await cloud_api.async_voice_connection_details(auth_cloud_mock)
     assert len(aioclient_mock.mock_calls) == 1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,7 +30,7 @@ def test_constructor_loads_info_from_constant(cloud_client):
                 "acme": "test-acme-directory-server",
                 "remotestate": "test-google-actions-report-state-url",
                 "account_link": "test-account-link-url",
-                "voice": "test-voice-api-url",
+                "servicehandlers": "test-servicehandlers-url",
                 "thingtalk": "test-thingtalk-url",
             }
         },

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -10,7 +10,7 @@ import hass_nabucasa.voice as voice
 @pytest.fixture
 def voice_api(auth_cloud_mock):
     """Voice api fixture."""
-    auth_cloud_mock.voice_server = "test.local"
+    auth_cloud_mock.servicehandlers_server = "test.local"
     return voice.Voice(auth_cloud_mock)
 
 
@@ -18,7 +18,7 @@ def voice_api(auth_cloud_mock):
 def mock_voice_connection_details(aioclient_mock):
     """Mock voice connection details."""
     aioclient_mock.get(
-        "https://test.local/connection_details",
+        "https://test.local/voice/connection_details",
         json={
             "authorized_key": "test-key",
             "endpoint_stt": "stt-url",


### PR DESCRIPTION
This removes the `voice_server` argument for develoment servers, and replaces it with `servicehandlers_server`

The voice service is also changed from `https://voice-api.nabucasa.com/connection_details` to `https://servicehandlers.nabucasa.com/voice/connection_details`