### PR TITLE
Fix calls to client.cloud_connected

### DIFF
--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -137,6 +137,16 @@ class CloudIoT(iot_base.BaseIoT):
         with suppress(ConnectionResetError):
             await self.client.send_json(response)
 
+    async def _connected(self) -> None:
+        """Handle connected."""
+        super()._connected()
+        await self.cloud.client.cloud_connected()
+
+    async def _disconnected(self) -> None:
+        """Handle connected."""
+        super()._disconnected()
+        await self.cloud.client.cloud_disconnected()
+
 
 @HANDLERS.register("system")
 async def async_handle_system(cloud: Cloud[_ClientT], payload: dict[str, Any]) -> None:

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -139,12 +139,12 @@ class CloudIoT(iot_base.BaseIoT):
 
     async def _connected(self) -> None:
         """Handle connected."""
-        super()._connected()
+        await super()._connected()
         await self.cloud.client.cloud_connected()
 
     async def _disconnected(self) -> None:
         """Handle connected."""
-        super()._disconnected()
+        await super()._disconnected()
         await self.cloud.client.cloud_disconnected()
 
 

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -140,11 +140,7 @@ class BaseIoT:
                 self._logger.exception("Unexpected error")
 
             if self.state == STATE_CONNECTED:
-                await self.cloud.client.cloud_disconnected()
-                if self._on_disconnect:
-                    await gather_callbacks(
-                        self._logger, "on_disconnect", self._on_disconnect
-                    )
+                await self._disconnected()
 
             if self.close_requested:
                 break
@@ -308,6 +304,10 @@ class BaseIoT:
         self.state = STATE_CONNECTED
         self._logger.info("Connected")
 
-        await self.cloud.client.cloud_connected()
         if self._on_connect:
             await gather_callbacks(self._logger, "on_connect", self._on_connect)
+
+    async def _disconnected(self) -> None:
+        """Handle connected."""
+        if self._on_disconnect:
+            await gather_callbacks(self._logger, "on_disconnect", self._on_disconnect)


### PR DESCRIPTION
Fix calls to `client.cloud_connected`, we should only call the methods from the `CloudIoT` class