### PR TITLE
Wait with loading until after _finish_challenge

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -427,7 +427,6 @@ class AcmeHandler:
                 _LOGGER.info("Waiting 60 seconds for publishing DNS to ACME provider")
                 await asyncio.sleep(60)
                 await self.cloud.run_executor(self._answer_challenge, challenge)
-                await self.load_certificate()
             finally:
                 try:
                     async with async_timeout.timeout(30):


### PR DESCRIPTION
The certificate has not been generated at this point. There is no need to call this here.
We do this after _finish_challenge has been completed.