### PR TITLE
Mock wait_for_close in AiohttpClientMockResponse

### DIFF
--- a/tests/utils/aiohttp.py
+++ b/tests/utils/aiohttp.py
@@ -239,6 +239,9 @@ class AiohttpClientMockResponse:
     def close(self):
         """Mock close."""
 
+    async def wait_for_close(self):
+        """Mock wait_for_close."""
+
 
 @contextmanager
 def mock_aiohttp_client(loop):


### PR DESCRIPTION
As we set a loose pin for aiohttp its now updated to > 3.9 in our tests and starting to fail because this method was missing.
ref https://github.com/NabuCasa/hass-nabucasa/actions/runs/7065848545/job/19236641817?pr=532