### PR TITLE
Handle bad DNS configuration while generating certificate

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -76,6 +76,16 @@ class AcmeHandler:
         self._email = email
 
     @property
+    def email(self) -> str:
+        """Return the email."""
+        return self._email
+
+    @property
+    def domains(self) -> list[str]:
+        """Return the domains."""
+        return self._domains
+
+    @property
     def path_account_key(self) -> Path:
         """Return path of account key."""
         return Path(self.cloud.path(FILE_ACCOUNT_KEY))

--- a/hass_nabucasa/cloud_api.py
+++ b/hass_nabucasa/cloud_api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from functools import wraps
+import json
 import logging
 from typing import (
     TYPE_CHECKING,
@@ -181,4 +182,18 @@ async def async_migrate_paypal_agreement(cloud: Cloud[_ClientT]) -> dict[str, An
     _do_log_response(resp)
     resp.raise_for_status()
     data: dict[str, Any] = await resp.json()
+    return data
+
+
+@_check_token
+async def async_resolve_cname(cloud: Cloud[_ClientT], hostname: str) -> list[str]:
+    """Resolve DNS CNAME."""
+    resp = await cloud.websession.post(
+        f"https://{cloud.accounts_server}/instance/resolve_dns_cname",
+        headers={"authorization": cloud.id_token, USER_AGENT: cloud.client.client_name},
+        data=json.dumps({"hostname": hostname}),
+    )
+    _do_log_response(resp)
+    resp.raise_for_status()
+    data: list[str] = await resp.json()
     return data

--- a/tests/common.py
+++ b/tests/common.py
@@ -163,6 +163,13 @@ class MockAcme:
         self.expire_date = None
         self.fingerprint = None
 
+        self.email = "test@nabucasa.inc"
+
+    @property
+    def domains(self):
+        """Return all domains."""
+        return self.alternative_names
+
     def set_false(self):
         """Set certificate as not valid."""
         self.is_valid = False


### PR DESCRIPTION
This change brings in DNS validation before generating certificates.

If a bad DNS configuration is detected when there is < 25 days remaining a repair issue will be created with a warning severity.
If a bad DNS configuration is detected when there is < 18 days remaining a repair issue will be created with a error severity, and the acme client will be recreated without the custom domain.