### PR TITLE
Change order of steps in Upload Python Package workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -18,14 +18,15 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Verify version
-        run: |
-          [[ "$(python3 setup.py --version)" == "${{ github.event.release.tag_name }}" ]]
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
+
+      - name: Verify version
+        run: |
+          [[ "$(python3 setup.py --version)" == "${{ github.event.release.tag_name }}" ]]
+
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
`setuptools` is missing when we do the version check <https://github.com/NabuCasa/hass-nabucasa/actions/runs/7209407335/job/19640283915>