### PR TITLE
Fix portal link

### DIFF
--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -54,7 +54,7 @@ using the service.
 
 MESSAGE_REMOTE_READY = """
 Your remote access is now available.
-You can manage your connectivity on the [Cloud Panel](/config/cloud) or with our [Portal](https://account.nabucasa.com/).
+You can manage your connectivity on the [Cloud panel](/config/cloud) or with our [portal](https://account.nabucasa.com/).
 """
 
 MESSAGE_REMOTE_SETUP = """

--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -54,7 +54,7 @@ using the service.
 
 MESSAGE_REMOTE_READY = """
 Your remote access is now available.
-You can manage your connectivity on the [Cloud Panel](/config/cloud) or with our [Portal](account.nabucasa.com/).
+You can manage your connectivity on the [Cloud Panel](/config/cloud) or with our [Portal](https://account.nabucasa.com/).
 """
 
 MESSAGE_REMOTE_SETUP = """


### PR DESCRIPTION
The existing portal link does not render correctly in the frontend persistent notification tray. 

Without an http prefix, the link is dropped and just points to the page the user is currently on. 

See https://github.com/home-assistant/frontend/issues/19149