### PR TITLE
Clean up event_loop fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,20 +12,24 @@ from .common import MockClient
 logging.basicConfig(level=logging.DEBUG)
 
 
+@pytest.fixture(name="loop")
+async def loop_fixture():
+    """Return the event loop."""
+    return asyncio.get_running_loop()
+
+
 @pytest.fixture
-async def aioclient_mock(event_loop):
+async def aioclient_mock(loop):
     """Fixture to mock aioclient calls."""
-    loop = event_loop
     with mock_aiohttp_client(loop) as mock_session:
         yield mock_session
 
 
 @pytest.fixture
-async def cloud_mock(event_loop, aioclient_mock):
+async def cloud_mock(loop, aioclient_mock):
     """Yield a simple cloud mock."""
-    loop = event_loop
     cloud = MagicMock(name="Mock Cloud", is_logged_in=True)
-    cloud.run_task = loop.create_task
+    cloud.run_task = asyncio.create_task
 
     def _executor(call, *args):
         """Run executor."""

--- a/tests/test_iot.py
+++ b/tests/test_iot.py
@@ -219,9 +219,8 @@ async def test_send_message_no_answer(cloud_mock_iot):
     assert msg["payload"] == {"msg": "yo"}
 
 
-async def test_send_message_answer(event_loop, cloud_mock_iot):
+async def test_send_message_answer(cloud_mock_iot):
     """Test sending a message that expects an answer."""
-    loop = event_loop
     cloud_iot = iot.CloudIoT(cloud_mock_iot)
     cloud_iot.state = iot_base.STATE_CONNECTED
     cloud_iot.client = MagicMock(send_json=AsyncMock())
@@ -229,7 +228,7 @@ async def test_send_message_answer(event_loop, cloud_mock_iot):
     uuid = 5
 
     with patch("hass_nabucasa.iot.uuid.uuid4", return_value=MagicMock(hex=uuid)):
-        send_task = loop.create_task(
+        send_task = asyncio.create_task(
             cloud_iot.async_send_message("webhook", {"msg": "yo"})
         )
         await asyncio.sleep(0)

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -451,10 +451,9 @@ async def test_get_certificate_details(
 
 
 async def test_certificate_task_no_backend(
-    event_loop, auth_cloud_mock, acme_mock, mock_cognito, aioclient_mock, snitun_mock
+    auth_cloud_mock, acme_mock, mock_cognito, aioclient_mock, snitun_mock
 ):
     """Initialize backend."""
-    loop = event_loop
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
     remote = RemoteUI(auth_cloud_mock)
@@ -482,7 +481,9 @@ async def test_certificate_task_no_backend(
     with patch("hass_nabucasa.utils.next_midnight", return_value=0), patch(
         "random.randint", return_value=0
     ):
-        acme_task = remote._acme_task = loop.create_task(remote._certificate_handler())
+        acme_task = remote._acme_task = asyncio.create_task(
+            remote._certificate_handler()
+        )
         await asyncio.sleep(0.1)
         assert acme_mock.call_issue
         assert snitun_mock.call_start
@@ -494,10 +495,9 @@ async def test_certificate_task_no_backend(
 
 
 async def test_certificate_task_renew_cert(
-    event_loop, auth_cloud_mock, acme_mock, mock_cognito, aioclient_mock, snitun_mock
+    auth_cloud_mock, acme_mock, mock_cognito, aioclient_mock, snitun_mock
 ):
     """Initialize backend."""
-    loop = event_loop
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
     remote = RemoteUI(auth_cloud_mock)
@@ -525,7 +525,9 @@ async def test_certificate_task_renew_cert(
     with patch("hass_nabucasa.utils.next_midnight", return_value=0), patch(
         "random.randint", return_value=0
     ):
-        acme_task = remote._acme_task = loop.create_task(remote._certificate_handler())
+        acme_task = remote._acme_task = asyncio.create_task(
+            remote._certificate_handler()
+        )
 
         await remote.load_backend()
         await asyncio.sleep(0.1)


### PR DESCRIPTION
- Clean up the use of the `event_loop` fixture in tests. Also replace the use of `loop.create_task` with `asyncio.create_task` in tests.
- This resolves deprecation warnings like this:

  ```
  tests/test_google_report_state.py:33
  tests/test_google_report_state.py:33: PytestDeprecationWarning: test_send_messages is asynchronous and explicitly requests the "event_loop" fixture. Asynchronous fixtures and test functions should use "asyncio.get_running_loop()" instead.
    async def test_send_messages(event_loop, ws_server):
  ```