### PR TITLE
Remove run_task

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -172,7 +172,7 @@ class Cloud(Generic[_ClientT]):
 
         if not self.started and not self.subscription_expired:
             self.started = True
-            return self.run_task(self._start())
+            return asyncio.create_task(self._start())
 
         if self.started and self.subscription_expired:
             self.started = False
@@ -203,13 +203,6 @@ class Cloud(Generic[_ClientT]):
         Async friendly.
         """
         return Path(self.client.base_path, CONFIG_DIR, *parts)
-
-    def run_task(self, coro: Coroutine) -> asyncio.Task:
-        """Schedule a task.
-
-        Return a task.
-        """
-        return self.client.loop.create_task(coro)
 
     def run_executor(self, callback: Callable, *args: Any) -> asyncio.Future:
         """Run function inside executore.
@@ -295,7 +288,7 @@ class Cloud(Generic[_ClientT]):
         self.access_token = info["access_token"]
         self.refresh_token = info["refresh_token"]
 
-        self._init_task = self.run_task(self._finish_initialize())
+        self._init_task = asyncio.create_task(self._finish_initialize())
 
     async def _finish_initialize(self) -> None:
         """Finish initializing the cloud component (load auth and maybe start)."""

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 import json
 import logging
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Coroutine, Generic, Mapping, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Mapping, TypeVar
 
 import aiohttp
 from atomicwrites import atomic_write

--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -95,7 +95,7 @@ class CognitoAuth:
 
     async def on_connect(self) -> None:
         """When the instance is connected."""
-        self._refresh_task = self.cloud.run_task(self._async_handle_token_refresh())
+        self._refresh_task = asyncio.create_task(self._async_handle_token_refresh())
 
     async def on_disconnect(self) -> None:
         """When the instance is disconnected."""
@@ -206,7 +206,7 @@ class CognitoAuth:
                 )
 
                 # Don't await it because it could cancel this task
-                self.cloud.run_task(self.cloud.logout())
+                asyncio.create_task(self.cloud.logout())
                 raise
 
     async def async_renew_access_token(self) -> None:

--- a/hass_nabucasa/google_report_state.py
+++ b/hass_nabucasa/google_report_state.py
@@ -64,7 +64,7 @@ class GoogleReportState(iot_base.BaseIoT):
         # Since connect is async, guard against send_message called twice in parallel.
         async with self._connect_lock:
             if self.state == iot_base.STATE_DISCONNECTED:
-                self.cloud.run_task(self.connect())
+                asyncio.create_task(self.connect())
                 # Give connect time to start up and change state.
                 await asyncio.sleep(0)
 
@@ -100,7 +100,7 @@ class GoogleReportState(iot_base.BaseIoT):
 
     async def _async_on_connect(self) -> None:
         """On Connect handler."""
-        self._message_sender_task = self.cloud.run_task(self._async_message_sender())
+        self._message_sender_task = asyncio.create_task(self._async_message_sender())
 
     async def _async_on_disconnect(self) -> None:
         """On disconnect handler."""

--- a/hass_nabucasa/iot.py
+++ b/hass_nabucasa/iot.py
@@ -62,7 +62,7 @@ class CloudIoT(iot_base.BaseIoT):
         """Start the CloudIoT server."""
         if self.cloud.subscription_expired:
             return
-        self.cloud.run_task(self.connect())
+        asyncio.create_task(self.connect())
 
     async def async_send_message(
         self,
@@ -99,7 +99,7 @@ class CloudIoT(iot_base.BaseIoT):
                 response_handler.set_exception(ErrorMessage(msg["error"]))
             return
 
-        self.cloud.run_task(self._async_handle_handler_message(msg))
+        asyncio.create_task(self._async_handle_handler_message(msg))
 
     async def _async_handle_handler_message(self, message: dict[str, Any]) -> None:
         """Handle incoming IoT message."""

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -164,7 +164,7 @@ class BaseIoT:
     async def _wait_retry(self) -> None:
         """Wait until it's time till the next retry."""
         # Sleep 2^tries + 0…tries*3 seconds between retries
-        self.retry_task = self.cloud.run_task(
+        self.retry_task = asyncio.create_task(
             asyncio.sleep(2 ** min(9, self.tries) + random.randint(0, self.tries * 3))
         )
         await self.retry_task

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -112,7 +112,7 @@ class RemoteUI:
         """Start remote UI loop."""
         if self.cloud.subscription_expired:
             return
-        self._acme_task = self.cloud.run_task(self._certificate_handler())
+        self._acme_task = asyncio.create_task(self._certificate_handler())
         await self._info_loaded.wait()
 
     async def stop(self) -> None:
@@ -308,7 +308,7 @@ class RemoteUI:
         )
         # Connect to remote is autostart enabled
         if self.cloud.client.remote_autostart:
-            self.cloud.run_task(self.connect())
+            asyncio.create_task(self.connect())
 
         return True
 
@@ -442,11 +442,11 @@ class RemoteUI:
                 and not self._reconnect_task
                 and not (insecure or forbidden)
             ):
-                self._reconnect_task = self.cloud.run_task(self._reconnect_snitun())
+                self._reconnect_task = asyncio.create_task(self._reconnect_snitun())
 
             # Disconnect if the instance is mark as insecure and we're in reconnect mode
             elif self._reconnect_task and (insecure or forbidden):
-                self.cloud.run_task(self.disconnect())
+                asyncio.create_task(self.disconnect())
 
     async def disconnect(self, clear_snitun_token: bool = False) -> None:
         """Disconnect from snitun server."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ async def aioclient_mock(loop):
 async def cloud_mock(loop, aioclient_mock):
     """Yield a simple cloud mock."""
     cloud = MagicMock(name="Mock Cloud", is_logged_in=True)
-    cloud.run_task = asyncio.create_task
 
     def _executor(call, *args):
         """Run executor."""

--- a/tests/test_google_report_state.py
+++ b/tests/test_google_report_state.py
@@ -12,7 +12,6 @@ async def create_grs(ws_server, server_msg_handler) -> GoogleReportState:
     """Create a grs instance."""
     client = await ws_server(server_msg_handler)
     mock_cloud = Mock(
-        run_task=asyncio.create_task,
         subscription_expired=False,
         remotestate_server="mock-report-state-url.com",
         auth=Mock(async_check_token=AsyncMock()),


### PR DESCRIPTION
- This removes the `run_task` method. It's no longer needed as the recommended way to create a task is by using `asyncio.create_task` instead of `loop.create_task`.