### PR TITLE
Bump min cryptography version from 2.8 to 42.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "snitun==0.36.2",
         "ciso8601>=2.3.0",
         "acme==2.8.0",
-        "cryptography>=2.8",
+        "cryptography>=42.0.0",
         "attrs>=19.3",
         "aiohttp>=3.6.1",
         "atomicwrites-homeassistant==1.4.1",


### PR DESCRIPTION
Related to https://github.com/home-assistant/core/issues/109262
This new property was added in 42.0.0, so we need to bump the minimum cryptography version before we can replace it.