### PR TITLE
Recreate acme when JWS verification fails

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -46,7 +46,7 @@ class AcmeChallengeError(AcmeClientError):
     """Raise if a challenge fails."""
 
 
-class AcmeJWSVerificationError(AcmeClientError):
+class AcmeJWTVerificationError(AcmeClientError):
     """Raise if a JWS verification fails."""
 
 
@@ -278,12 +278,12 @@ class AcmeHandler:
                 and err.typ == "urn:ietf:params:acme:error:malformed"
                 and err.detail == "JWS verification error"
             ):
-                raise AcmeJWSVerificationError(
+                raise AcmeJWTVerificationError(
                     f"JWS verification failed: {err}"
-                ) from err
+                ) from None
             raise AcmeChallengeError(
                 f"Can't order a new ACME challenge: {err}"
-            ) from err
+            ) from None
 
     def _start_challenge(self, order: messages.OrderResource) -> list[ChallengeHandler]:
         """Initialize domain challenge and return token."""

--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -46,7 +46,7 @@ class AcmeChallengeError(AcmeClientError):
     """Raise if a challenge fails."""
 
 
-class AcmeJWTVerificationError(AcmeClientError):
+class AcmeJWSVerificationError(AcmeClientError):
     """Raise if a JWS verification fails."""
 
 
@@ -278,7 +278,7 @@ class AcmeHandler:
                 and err.typ == "urn:ietf:params:acme:error:malformed"
                 and err.detail == "JWS verification error"
             ):
-                raise AcmeJWTVerificationError(
+                raise AcmeJWSVerificationError(
                     f"JWS verification failed: {err}"
                 ) from None
             raise AcmeChallengeError(

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -18,7 +18,7 @@ from snitun.utils.aes import generate_aes_keyset
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
 from . import cloud_api, const, utils
-from .acme import AcmeClientError, AcmeHandler, AcmeJWTVerificationError
+from .acme import AcmeClientError, AcmeHandler, AcmeJWSVerificationError
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
@@ -262,8 +262,8 @@ class RemoteUI:
             try:
                 self._certificate_status = CertificateStatus.GENERATING
                 await self._acme.issue_certificate()
-            except (AcmeJWTVerificationError, AcmeClientError) as err:
-                if isinstance(err, AcmeJWTVerificationError):
+            except (AcmeJWSVerificationError, AcmeClientError) as err:
+                if isinstance(err, AcmeJWSVerificationError):
                     await self._recreate_acme(domains, email)
                 self.cloud.client.user_message(
                     "cloud_remote_acme",

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -18,7 +18,7 @@ from snitun.utils.aes import generate_aes_keyset
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
 from . import cloud_api, const, utils
-from .acme import AcmeClientError, AcmeHandler
+from .acme import AcmeClientError, AcmeHandler, AcmeJWSVerificationError
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
@@ -262,7 +262,9 @@ class RemoteUI:
             try:
                 self._certificate_status = CertificateStatus.GENERATING
                 await self._acme.issue_certificate()
-            except AcmeClientError:
+            except (AcmeJWSVerificationError, AcmeClientError) as err:
+                if isinstance(err, AcmeJWSVerificationError):
+                    await self._recreate_acme(domains, email)
                 self.cloud.client.user_message(
                     "cloud_remote_acme",
                     "Home Assistant Cloud",

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -18,7 +18,7 @@ from snitun.utils.aes import generate_aes_keyset
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
 from . import cloud_api, const, utils
-from .acme import AcmeClientError, AcmeHandler, AcmeJWSVerificationError
+from .acme import AcmeClientError, AcmeHandler, AcmeJWTVerificationError
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
@@ -262,8 +262,8 @@ class RemoteUI:
             try:
                 self._certificate_status = CertificateStatus.GENERATING
                 await self._acme.issue_certificate()
-            except (AcmeJWSVerificationError, AcmeClientError) as err:
-                if isinstance(err, AcmeJWSVerificationError):
+            except (AcmeJWTVerificationError, AcmeClientError) as err:
+                if isinstance(err, AcmeJWTVerificationError):
                     await self._recreate_acme(domains, email)
                 self.cloud.client.user_message(
                     "cloud_remote_acme",

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -3,8 +3,12 @@ import asyncio
 from datetime import timedelta
 from unittest.mock import patch
 
+from acme import client, messages
+
+
 import pytest
 from hass_nabucasa import utils
+from hass_nabucasa.acme import AcmeHandler
 
 from hass_nabucasa.const import (
     DISPATCH_REMOTE_BACKEND_DOWN,
@@ -868,3 +872,130 @@ async def test_regeneration_without_warning_for_good_dns_config(
     await asyncio.sleep(0.1)
 
     assert snitun_mock.call_disconnect
+
+
+async def test_certificate_task_renew_cert_jws_failiure(
+    auth_cloud_mock, mock_cognito, aioclient_mock, snitun_mock
+):
+    """Initialize backend."""
+    auth_cloud_mock.servicehandlers_server = "test.local"
+
+    class _MockAcmeClient(client.ClientV2):
+        def __init__(self) -> None:
+            pass
+
+        def new_order(self, _):
+            raise messages.Error.from_json(
+                {
+                    "type": "urn:ietf:params:acme:error:malformed",
+                    "detail": "JWS verification error",
+                }
+            )
+
+    class _MockAcme(AcmeHandler):
+        call_reset = False
+        cloud = auth_cloud_mock
+
+        @property
+        def certificate_available(self):
+            return True
+
+        @property
+        def alternative_names(self):
+            return ["test.dui.nabu.casa"]
+
+        def _generate_csr(self):
+            return b""
+
+        def _create_client(self):
+            self._acme_client = _MockAcmeClient()
+
+        async def reset_acme(self):
+            self.call_reset = True
+
+    remote = RemoteUI(auth_cloud_mock)
+
+    aioclient_mock.post(
+        "https://test.local/instance/register",
+        json={
+            "domain": "test.dui.nabu.casa",
+            "email": "test@nabucasa.inc",
+            "server": "rest-remote.nabu.casa",
+        },
+    )
+
+    with patch(
+        "hass_nabucasa.remote.AcmeHandler",
+        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc"),
+    ):
+        assert remote._certificate_status is None
+        await remote.load_backend()
+
+    await asyncio.sleep(0.1)
+    assert remote._acme.call_reset
+    assert remote._certificate_status is CertificateStatus.ERROR
+
+    await remote.stop()
+
+
+async def test_certificate_task_renew_cert_some_other_failure_failiure(
+    auth_cloud_mock, mock_cognito, aioclient_mock, snitun_mock
+):
+    """Initialize backend."""
+    auth_cloud_mock.servicehandlers_server = "test.local"
+
+    class _MockAcmeClient(client.ClientV2):
+        def __init__(self) -> None:
+            pass
+
+        def new_order(self, _):
+            raise messages.Error.from_json(
+                {
+                    "detail": "Boom",
+                }
+            )
+
+    class _MockAcme(AcmeHandler):
+        call_reset = False
+        cloud = auth_cloud_mock
+
+        @property
+        def certificate_available(self):
+            return True
+
+        @property
+        def alternative_names(self):
+            return ["test.dui.nabu.casa"]
+
+        def _generate_csr(self):
+            return b""
+
+        def _create_client(self):
+            self._acme_client = _MockAcmeClient()
+
+        async def reset_acme(self):
+            self.call_reset = True
+
+    remote = RemoteUI(auth_cloud_mock)
+
+    aioclient_mock.post(
+        "https://test.local/instance/register",
+        json={
+            "domain": "test.dui.nabu.casa",
+            "email": "test@nabucasa.inc",
+            "server": "rest-remote.nabu.casa",
+        },
+    )
+
+    with patch(
+        "hass_nabucasa.remote.AcmeHandler",
+        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc"),
+    ):
+        assert remote._certificate_status is None
+        await remote.load_backend()
+
+    await asyncio.sleep(0.1)
+    assert not remote._acme.call_reset
+    assert remote._certificate_status is CertificateStatus.ERROR
+
+    await remote.stop()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -874,8 +874,39 @@ async def test_regeneration_without_warning_for_good_dns_config(
     assert snitun_mock.call_disconnect
 
 
-async def test_certificate_task_renew_cert_jws_failiure(
-    auth_cloud_mock, mock_cognito, aioclient_mock, snitun_mock
+@pytest.mark.parametrize(
+    ("json_error", "should_reset"),
+    (
+        (
+            {
+                "type": "urn:ietf:params:acme:error:malformed",
+                "detail": "JWS verification error",
+            },
+            True,
+        ),
+        (
+            {
+                "type": "urn:ietf:params:acme:error:malformed",
+                "detail": "Some other malformed reason",
+            },
+            False,
+        ),
+        (
+            {
+                "type": "about:blank",
+                "detail": "Boom",
+            },
+            False,
+        ),
+    ),
+)
+async def test_acme_client_new_order_errors(
+    auth_cloud_mock,
+    mock_cognito,
+    aioclient_mock,
+    snitun_mock,
+    json_error,
+    should_reset,
 ):
     """Initialize backend."""
     auth_cloud_mock.servicehandlers_server = "test.local"
@@ -885,12 +916,7 @@ async def test_certificate_task_renew_cert_jws_failiure(
             pass
 
         def new_order(self, _):
-            raise messages.Error.from_json(
-                {
-                    "type": "urn:ietf:params:acme:error:malformed",
-                    "detail": "JWS verification error",
-                }
-            )
+            raise messages.Error.from_json(json_error)
 
     class _MockAcme(AcmeHandler):
         call_reset = False
@@ -932,70 +958,7 @@ async def test_certificate_task_renew_cert_jws_failiure(
         await remote.load_backend()
 
     await asyncio.sleep(0.1)
-    assert remote._acme.call_reset
-    assert remote._certificate_status is CertificateStatus.ERROR
-
-    await remote.stop()
-
-
-async def test_certificate_task_renew_cert_some_other_failure_failiure(
-    auth_cloud_mock, mock_cognito, aioclient_mock, snitun_mock
-):
-    """Initialize backend."""
-    auth_cloud_mock.servicehandlers_server = "test.local"
-
-    class _MockAcmeClient(client.ClientV2):
-        def __init__(self) -> None:
-            pass
-
-        def new_order(self, _):
-            raise messages.Error.from_json(
-                {
-                    "detail": "Boom",
-                }
-            )
-
-    class _MockAcme(AcmeHandler):
-        call_reset = False
-        cloud = auth_cloud_mock
-
-        @property
-        def certificate_available(self):
-            return True
-
-        @property
-        def alternative_names(self):
-            return ["test.dui.nabu.casa"]
-
-        def _generate_csr(self):
-            return b""
-
-        def _create_client(self):
-            self._acme_client = _MockAcmeClient()
-
-        async def reset_acme(self):
-            self.call_reset = True
-
-    remote = RemoteUI(auth_cloud_mock)
-
-    aioclient_mock.post(
-        "https://test.local/instance/register",
-        json={
-            "domain": "test.dui.nabu.casa",
-            "email": "test@nabucasa.inc",
-            "server": "rest-remote.nabu.casa",
-        },
-    )
-
-    with patch(
-        "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc"),
-    ):
-        assert remote._certificate_status is None
-        await remote.load_backend()
-
-    await asyncio.sleep(0.1)
-    assert not remote._acme.call_reset
+    assert remote._acme.call_reset == should_reset
     assert remote._certificate_status is CertificateStatus.ERROR
 
     await remote.stop()


### PR DESCRIPTION
Add additional handling to the `urn:ietf:params:acme:error:malformed` error type with "JWS verification error" as the message to discard local files and recreate them.