### PR TITLE
Bump syrup from 4.6.0 to 4.6.1

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -8,4 +8,4 @@ pytest==7.4.4
 types_atomicwrites==1.4.5.1
 types_pyOpenSSL==24.0.0.20240130
 xmltodict==0.13.0
-syrupy==4.6.0
+syrupy==4.6.1


### PR DESCRIPTION
Diff https://github.com/tophat/syrupy/compare/v4.6.0...v4.6.1

This will unblock #555