### PR TITLE
Limit snitun error to only log if we are reconnecting

### DIFF
--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -415,11 +415,11 @@ class RemoteUI:
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout connecting to snitun server")
         except SniTunConnectionError as err:
-            can_reconnect = self._snitun and not self._reconnect_task
+            reconnecting = self._reconnect_task is not None
             _LOGGER.log(
-                logging.INFO if can_reconnect else logging.ERROR,
+                 logging.ERROR if reconnecting else logging.INFO,
                 "Connection problem to snitun server%s (%s)",
-                ", reconnecting" if can_reconnect else "",
+                ", reconnecting" if not reconnecting else "",
                 err,
             )
         except RemoteBackendError:

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -417,7 +417,7 @@ class RemoteUI:
         except SniTunConnectionError as err:
             reconnecting = self._reconnect_task is not None
             _LOGGER.log(
-                 logging.ERROR if reconnecting else logging.INFO,
+                logging.ERROR if reconnecting else logging.INFO,
                 "Connection problem to snitun server%s (%s)",
                 ", reconnecting" if not reconnecting else "",
                 err,

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -415,11 +415,9 @@ class RemoteUI:
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout connecting to snitun server")
         except SniTunConnectionError as err:
-            reconnecting = self._reconnect_task is not None
             _LOGGER.log(
-                logging.ERROR if reconnecting else logging.INFO,
-                "Connection problem to snitun server%s (%s)",
-                ", reconnecting" if not reconnecting else "",
+                logging.ERROR if self._reconnect_task is not None else logging.INFO,
+                "Connection problem to snitun server (%s)",
                 err,
             )
         except RemoteBackendError:


### PR DESCRIPTION
We only need this to be an error if it happens during reconnect.
As this will hit on busy systems during startup, logging as en error in other cases only raises confusion.