### PR TITLE
Add pypa/gh-action-pypi-publish for publishing

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -1,16 +1,14 @@
-# This workflows will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
 name: Upload Python Package
 
 on:
   release:
     types: [published]
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
+permissions: {}
 
+jobs:
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -25,15 +23,35 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools build twine
+          pip install setuptools build
 
       - name: Build
         run: |
           python -m build
 
-      - name: Publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          twine upload dist/*
+      - name: "Upload dists"
+        uses: "actions/upload-artifact@v4"
+        with:
+          name: "dist"
+          path: "dist/"
+          if-no-files-found: error
+          retention-days: 5
+
+  publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    needs: "build"
+    environment:
+      name: release
+      url: https://pypi.org/p/hass-nabucasa
+    permissions:
+      id-token: write
+    steps:
+    - name: "Download dists"
+      uses: "actions/download-artifact@v4"
+      with:
+        name: "dist"
+        path: "dist/"
+
+    - name: "Publish dists to PyPI"
+      uses: "pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06" # v1.8.12

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -55,4 +55,5 @@ jobs:
         path: "dist/"
 
     - name: Publish dists to PyPI
+      # Pinned to a commit for security purposes
       uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -2,7 +2,8 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types:
+      - published
 
 permissions: {}
 
@@ -10,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.x"
 
@@ -29,8 +30,8 @@ jobs:
         run: |
           python -m build
 
-      - name: "Upload dists"
-        uses: "actions/upload-artifact@v4"
+      - name: Upload dists
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: "dist"
           path: "dist/"
@@ -47,11 +48,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - name: "Download dists"
-      uses: "actions/download-artifact@v4"
+    - name: Download dists
+      uses: actions/download-artifact@v4.1.3
       with:
         name: "dist"
         path: "dist/"
 
-    - name: "Publish dists to PyPI"
-      uses: "pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06" # v1.8.12
+    - name: Publish dists to PyPI
+      uses: pypa/gh-action-pypi-publish@e53eb8b103ffcb59469888563dc324e3c8ba6f06 # v1.8.12


### PR DESCRIPTION
~~I'm unsure if these permissions are too restrictive, so Ill leave this PR in draft until I have verified that.~~

Did a simple test here, and it seems to be just fine:
- <https://github.com/ludeeus/ROOT/pull/218/files>
- <https://github.com/ludeeus/ROOT/actions/runs/8082784249?pr=218>
