### PR TITLE
Change JWT lib

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -357,6 +357,7 @@ class Cloud(Generic[_ClientT]):
     def _decode_claims(token: str) -> Mapping[str, Any]:
         """Decode the claims in a token."""
         decoded: Mapping[str, Any] = jwt.decode(
-            token, options={"verify_signature": False}
+            token,
+            options={"verify_signature": False},
         )
         return decoded

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -14,7 +14,7 @@ from collections.abc import Awaitable, Callable, Mapping
 
 import aiohttp
 from atomicwrites import atomic_write
-from jose import jwt
+import jwt
 
 from .auth import CloudError, CognitoAuth
 from .client import CloudClient
@@ -349,5 +349,7 @@ class Cloud(Generic[_ClientT]):
     @staticmethod
     def _decode_claims(token: str) -> Mapping[str, Any]:
         """Decode the claims in a token."""
-        decoded: Mapping[str, Any] = jwt.get_unverified_claims(token)
+        decoded: Mapping[str, Any] = jwt.decode(
+            token, options={"verify_signature": False}
+        )
         return decoded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "ciso8601>=2.3.0",
     "cryptography>=42.0.0",
     "pycognito==2024.1.0",
+    "PyJWT>=2.8.0",
     "snitun==0.36.2",
 ]
 description = "Home Assistant cloud integration by Nabu Casa, Inc."


### PR DESCRIPTION
As shown by #585 this lib has a dependency on `python-jose` but as it was not in the requirements CI for #585 is now failing.

Instead of adding that dependency to this lib which is no longer maintained, `PyJWT` was added instead.

Ideally, #593 would be merged before this to ensure that there are no behavior changes.