### PR TITLE
Add guard to recreate certificates on KV mismatch

### DIFF
--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -63,3 +63,8 @@ MESSAGE_REMOTE_SETUP = """
 Unable to create a certificate. We will automatically
 retry it and notify you when it's available.
 """
+
+MESSAGE_LOAD_CERTIFICATE_FAILURE = """
+Unable to load the certificate. We will automatically
+recreate it and notify you when it's available.
+"""

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -294,8 +294,6 @@ class RemoteUI:
             while self.cloud.client.aiohttp_runner is None:
                 await asyncio.sleep(1)
 
-        # Setup snitun / aiohttp wrapper
-        _LOGGER.debug("Initializing SniTun")
         try:
             context = await self._create_context()
         except SSLError as err:
@@ -303,12 +301,14 @@ class RemoteUI:
                 self.cloud.client.user_message(
                     "cloud_remote_acme",
                     "Home Assistant Cloud",
-                    const.MESSAGE_REMOTE_SETUP,
+                    const.MESSAGE_LOAD_CERTIFICATE_FAILURE,
                 )
                 await self._recreate_acme(domains, email)
             self._certificate_status = CertificateStatus.ERROR
             return False
 
+        # Setup snitun / aiohttp wrapper
+        _LOGGER.debug("Initializing SniTun")
         self._snitun = SniTunClientAioHttp(
             self.cloud.client.aiohttp_runner,
             context,


### PR DESCRIPTION
This adds a guard to recreate the certificates if the files loaded do not match. That in itself is not something that should happen, but can happen in case of a bad partial restore, or failure to write the files properly when generating.

The alternative to this is to remove the `.cloud` directory manually and restart, but as we can detect the specific reason here, we can handle it automatically.