### PR TITLE
Remove the safety dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ test = [
     "types_atomicwrites==1.4.5.1",
     "types_pyOpenSSL==24.0.0.20240311",
     "xmltodict==0.13.0",
-    "safety==3.0.1",
     "syrupy==4.6.1",
     "tomli==2.0.1",
 ]


### PR DESCRIPTION
Ref https://github.com/NabuCasa/hass-nabucasa/pull/610#issuecomment-2030718120
This does not seem to be in use, and is something that was copied when using https://github.com/home-assistant-libs/python-matter-server/blob/main/pyproject.toml#L52 as a model for the refactor (it does not seem to be in use in that repo as well)