### PR TITLE
Upgrade Python version to 3.12

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Hass-NabuCasa Dev",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3.11",
+  "image": "mcr.microsoft.com/vscode/devcontainers/python:1-3.12",
   "postCreateCommand": "python3 -m pip install -e .[test]",
   "postStartCommand": "python3 -m pip install -e .",
   "containerUser": "vscode",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5.2.0
         with:
-          python-version: "3.11"
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
@@ -36,22 +36,16 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    name: Run tests with Python ${{ matrix.python-version }}
+    name: Run tests
     needs: lint
-    strategy:
-      matrix:
-        python-version:
-          - "3.11"
-          - "3.12"
-
     steps:
       - uses: actions/checkout@v4.2.2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python "3.12"
         uses: actions/setup-python@v5.2.0
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          python-version: "3.12"
+          cache: "pip"
           cache-dependency-path: pyproject.toml
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Topic :: Internet :: Proxy Servers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Development Status :: 5 - Production/Stable",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
@@ -34,7 +33,7 @@ description = "Home Assistant cloud integration by Nabu Casa, Inc."
 license = {text = "GPL v3"}
 name = "hass-nabucasa"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 version = "0.82.0"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Home Assistant core uses Python 3.12, and with WebRTC coming, its libs package requires 3.12 as well.