### PR TITLE
Update Cloud ICE server fetch update and reset logic

### DIFF
--- a/hass_nabucasa/ice_servers.py
+++ b/hass_nabucasa/ice_servers.py
@@ -92,9 +92,8 @@ class IceServers:
                 # Task is canceled, stop it.
                 break
 
-            finally:
-                if self._ice_servers_listener is not None:
-                    await self._ice_servers_listener()
+            if self._ice_servers_listener is not None:
+                await self._ice_servers_listener()
 
             sleep_time = self._get_refresh_sleep_time()
             await asyncio.sleep(sleep_time)

--- a/hass_nabucasa/ice_servers.py
+++ b/hass_nabucasa/ice_servers.py
@@ -80,8 +80,6 @@ class IceServers:
             try:
                 self._ice_servers = await self._async_fetch_ice_servers()
 
-                if self._ice_servers_listener is not None:
-                    await self._ice_servers_listener()
             except ClientResponseError as err:
                 _LOGGER.error("Can't refresh ICE servers: %s", err.message)
 
@@ -90,12 +88,13 @@ class IceServers:
                 if err.status in (401, 403):
                     self._ice_servers = []
 
-                # we should update the listener as the ICE servers might have changed
-                if self._ice_servers_listener is not None:
-                    await self._ice_servers_listener()
             except asyncio.CancelledError:
                 # Task is canceled, stop it.
                 break
+
+            finally:
+                if self._ice_servers_listener is not None:
+                    await self._ice_servers_listener()
 
             sleep_time = self._get_refresh_sleep_time()
             await asyncio.sleep(sleep_time)

--- a/tests/test_ice_servers.py
+++ b/tests/test_ice_servers.py
@@ -7,6 +7,7 @@ import pytest
 from webrtc_models import RTCIceServer
 
 from hass_nabucasa import ice_servers
+from tests.utils.aiohttp import AiohttpClientMocker
 
 
 @pytest.fixture
@@ -17,8 +18,8 @@ def ice_servers_api(auth_cloud_mock) -> ice_servers.IceServers:
     return ice_servers.IceServers(auth_cloud_mock)
 
 
-@pytest.fixture(autouse=True)
-def mock_ice_servers(aioclient_mock):
+@pytest.fixture
+def mock_ice_servers(aioclient_mock: AiohttpClientMocker):
     """Mock ICE servers."""
     aioclient_mock.get(
         "https://example.com/test/webrtc/ice_servers",
@@ -34,6 +35,7 @@ def mock_ice_servers(aioclient_mock):
 
 async def test_ice_servers_listener_registration_triggers_periodic_ice_servers_update(
     ice_servers_api: ice_servers.IceServers,
+    mock_ice_servers,
 ):
     """Test that registering an ICE servers listener triggers a periodic update."""
     times_register_called_successfully = 0
@@ -78,6 +80,145 @@ async def test_ice_servers_listener_registration_triggers_periodic_ice_servers_u
     assert ice_servers_api._ice_servers == []
     assert ice_servers_api._ice_servers_listener is None
     assert ice_servers_api._ice_servers_listener_unregister is None
+
+
+async def test_ice_server_refresh_sets_ice_server_list_empty_on_expired_subscription(
+    ice_servers_api: ice_servers.IceServers,
+    aioclient_mock: AiohttpClientMocker,
+):
+    """Test that the ICE server list is set to empty when the subscription expires."""
+    times_register_called_successfully = 0
+
+    ice_servers_api._get_refresh_sleep_time = lambda: 0
+
+    ice_servers_api.cloud.subscription_expired = True
+
+    async def register_ice_servers(ice_servers: list[RTCIceServer]):
+        nonlocal times_register_called_successfully
+
+        # This assert will silently fail and variable will not be incremented
+        assert len(ice_servers) == 0
+
+        times_register_called_successfully += 1
+
+        def unregister():
+            pass
+
+        return unregister
+
+    await ice_servers_api.async_register_ice_servers_listener(register_ice_servers)
+
+    # Let the periodic update run once
+    await asyncio.sleep(0)
+
+    assert ice_servers_api._ice_servers == []
+
+    assert len(aioclient_mock.mock_calls) == 0
+    assert times_register_called_successfully == 1
+    assert ice_servers_api._refresh_task is not None
+    assert ice_servers_api._ice_servers_listener is not None
+    assert ice_servers_api._ice_servers_listener_unregister is not None
+
+
+async def test_ice_server_refresh_sets_ice_server_list_empty_on_401_403_client_error(
+    ice_servers_api: ice_servers.IceServers,
+    aioclient_mock: AiohttpClientMocker,
+):
+    """Test that ICE server list is empty when server returns 401 or 403 errors."""
+    aioclient_mock.get(
+        "https://example.com/test/webrtc/ice_servers",
+        status=403,
+        json={"message": "Boom!"},
+    )
+
+    times_register_called_successfully = 0
+
+    ice_servers_api._get_refresh_sleep_time = lambda: 0
+
+    ice_servers_api._ice_servers = [
+        RTCIceServer(
+            urls="turn:example.com:80",
+            username="12345678:test-user",
+            credential="secret-value",
+        ),
+    ]
+
+    async def register_ice_servers(ice_servers: list[RTCIceServer]):
+        nonlocal times_register_called_successfully
+
+        # This assert will silently fail and variable will not be incremented
+        assert len(ice_servers) == 0
+
+        times_register_called_successfully += 1
+
+        def unregister():
+            pass
+
+        return unregister
+
+    await ice_servers_api.async_register_ice_servers_listener(register_ice_servers)
+
+    # Let the periodic update run once
+    await asyncio.sleep(0)
+
+    assert ice_servers_api._ice_servers == []
+
+    assert times_register_called_successfully == 1
+    assert ice_servers_api._refresh_task is not None
+    assert ice_servers_api._ice_servers_listener is not None
+    assert ice_servers_api._ice_servers_listener_unregister is not None
+
+
+async def test_ice_server_refresh_keeps_ice_server_list_on_other_client_errors(
+    ice_servers_api: ice_servers.IceServers,
+    aioclient_mock,
+):
+    """Test that ICE server list is not set to empty when server returns an error."""
+    aioclient_mock.get(
+        "https://example.com/test/webrtc/ice_servers",
+        status=500,
+        json={"message": "Boom!"},
+    )
+
+    times_register_called_successfully = 0
+
+    ice_servers_api._get_refresh_sleep_time = lambda: 0
+
+    ice_servers_api._ice_servers = [
+        RTCIceServer(
+            urls="turn:example.com:80",
+            username="12345678:test-user",
+            credential="secret-value",
+        ),
+    ]
+
+    async def register_ice_servers(ice_servers: list[RTCIceServer]):
+        nonlocal times_register_called_successfully
+
+        # These asserts will silently fail and variable will not be incremented
+        assert len(ice_servers) == 1
+        assert ice_servers[0].urls == "turn:example.com:80"
+        assert ice_servers[0].username == "12345678:test-user"
+        assert ice_servers[0].credential == "secret-value"
+
+        times_register_called_successfully += 1
+
+        def unregister():
+            pass
+
+        return unregister
+
+    await ice_servers_api.async_register_ice_servers_listener(register_ice_servers)
+
+    # Let the periodic update run once
+    await asyncio.sleep(0)
+
+    assert ice_servers_api._ice_servers != []
+
+    assert times_register_called_successfully == 1
+    assert ice_servers_api._refresh_task is not None
+    assert ice_servers_api._ice_servers_listener is not None
+    assert ice_servers_api._ice_servers_listener_unregister is not None
 
 
 def test_get_refresh_sleep_time(ice_servers_api: ice_servers.IceServers):


### PR DESCRIPTION
There were some issues with the current logic, so it is updated in the following ways:
* If the cloud subscription has expired, there is no point in fetching new servers, and they should be set to an empty list.
* If, for some reason, the fetching does happen and 401 or 403 is returned, we should reset the ICE servers to an empty list instead of leaving them there and having the code reattempt fetching them based on the existing timestamps.
* The listener should be called even on request error as the servers might now change also in those cases.
* The listener should be called even on an empty ICE servers list as we don't need old servers with credentials to be left for HA to use.