### PR TITLE
Throw specific error for non-retryable codes

### DIFF
--- a/hass_nabucasa/files.py
+++ b/hass_nabucasa/files.py
@@ -129,10 +129,12 @@ class Files:
 
         if (
             resp.status == 400
-            and "message" in data
-            and (code := data["message"].split(" ")[0]) in _NON_RETRYABLE_ERROR_CODES
+            and isinstance(data, dict)
+            and (message := data.get("message"))
+            and (code := message.split(" ")[0])
+            and code in _NON_RETRYABLE_ERROR_CODES
         ):
-            raise FilesNonRetryableError(data["message"], code) from None
+            raise FilesNonRetryableError(message, code) from None
 
         resp.raise_for_status()
         return data

--- a/hass_nabucasa/files.py
+++ b/hass_nabucasa/files.py
@@ -24,12 +24,26 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _FILE_TRANSFER_TIMEOUT = 43200.0  # 43200s == 12h
+_NON_RETRYABLE_ERROR_CODES = {
+    "NC-CE-02",
+    "NC-CE-03",
+    "NC-SH-FH-03",
+}
 
 type StorageType = Literal["backup"]
 
 
 class FilesError(CloudError):
     """Exception raised when handling files."""
+
+
+class FilesNonRetryableError(FilesError):
+    """Exception raised when handling files that should not be retried."""
+
+    def __init__(self, message: str, code: str) -> None:
+        """Initialize."""
+        super().__init__(message)
+        self.code = code
 
 
 class _FilesHandlerUrlResponse(TypedDict):
@@ -113,6 +127,13 @@ class Files:
         if data is None:
             raise FilesError("Failed to parse response from files handler") from None
 
+        if (
+            resp.status == 400
+            and "message" in data
+            and (code := data["message"].split(" ")[0]) in _NON_RETRYABLE_ERROR_CODES
+        ):
+            raise FilesNonRetryableError(data["message"], code) from None
+
         resp.raise_for_status()
         return data
 
@@ -140,6 +161,8 @@ class Files:
                     "metadata": metadata,
                 },
             )
+        except FilesError:
+            raise
         except TimeoutError as err:
             raise FilesError(
                 "Timeout reached while trying to fetch upload details",
@@ -180,6 +203,8 @@ class Files:
                 method="GET",
                 path=f"/download_details/{storage_type}/{filename}",
             )
+        except FilesError:
+            raise
         except TimeoutError as err:
             raise FilesError(
                 "Timeout reached while trying to fetch download details",
@@ -200,6 +225,8 @@ class Files:
             self._do_log_response(response)
 
             response.raise_for_status()
+        except FilesError:
+            raise
         except TimeoutError as err:
             raise FilesError("Timeout reached while trying to download file") from err
         except ClientError as err:

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -7,7 +7,7 @@ from aiohttp import ClientError
 import pytest
 
 from hass_nabucasa import Cloud
-from hass_nabucasa.files import Files, FilesError
+from hass_nabucasa.files import Files, FilesError, FilesNonRetryableError
 from tests.utils.aiohttp import AiohttpClientMocker
 
 API_HOSTNAME = "example.com"
@@ -271,6 +271,18 @@ async def test_upload_exceptions_while_downloading(
 @pytest.mark.parametrize(
     "exception,getmockargs,log_msg",
     [
+        [
+            FilesNonRetryableError,
+            {"status": 400, "json": {"message": "NC-SH-FH-03 (abc-123)"}},
+            "Response from example.com/files/download_details/test/lorem.ipsum "
+            "(400) NC-SH-FH-03 (abc-123)",
+        ],
+        [
+            FilesNonRetryableError,
+            {"status": 400, "json": {"message": "NC-CE-03"}},
+            "Response from example.com/files/download_details/test/lorem.ipsum "
+            "(400) NC-CE-03",
+        ],
         [
             FilesError,
             {"status": 400, "json": {"message": "NC-CE-03"}},


### PR DESCRIPTION
These errors are not retryable.

This PR aims to allow for the separation of the error handling for these.
The code is added to the error class to allow Home Assistant to translate the meaning of them.