### PR TITLE
Add account API class

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -15,6 +15,7 @@ from aiohttp import ClientSession
 from atomicwrites import atomic_write
 import jwt
 
+from .account_api import AccountApi
 from .auth import CloudError, CognitoAuth
 from .client import CloudClient
 from .cloudhooks import Cloudhooks
@@ -74,6 +75,7 @@ class Cloud(Generic[_ClientT]):
         self.google_report_state = GoogleReportState(self)
         self.cloudhooks = Cloudhooks(self)
         self.remote = RemoteUI(self)
+        self.account = AccountApi(self)
         self.auth = CognitoAuth(self)
         self.files = Files(self)
         self.voice = Voice(self)

--- a/hass_nabucasa/account_api.py
+++ b/hass_nabucasa/account_api.py
@@ -1,0 +1,57 @@
+"""Manage account API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypedDict
+
+from .api import ApiBase, CloudApiError
+
+
+class AccountApiError(CloudApiError):
+    """Exception raised when handling account API."""
+
+
+class AccountServicesDetails(TypedDict):
+    """Details of the services."""
+
+    alexa: AccountServiceDetails
+    google_home: AccountServiceDetails
+    remote_access: AccountServiceDetails
+    stt: AccountServiceDetails
+    storage: AccountStorageServiceDetails
+    tts: AccountServiceDetails
+    webhooks: AccountServiceDetails
+    webrtc: AccountServiceDetails
+
+
+class AccountServiceDetails(TypedDict):
+    """Details of a service."""
+
+    available: bool
+
+
+class AccountStorageServiceDetails(AccountServiceDetails):
+    """Details of a service."""
+
+    limit_bytes: int
+
+
+class AccountApi(ApiBase):
+    """Class to help communicate with the instance API."""
+
+    @property
+    def hostname(self) -> str:
+        """Get the hostname."""
+        if TYPE_CHECKING:
+            assert self._cloud.servicehandlers_server is not None
+        return self._cloud.servicehandlers_server
+
+    async def services(self) -> AccountServicesDetails:
+        """Get the services details."""
+        try:
+            details: AccountServicesDetails = await self._call_cloud_api(
+                path="/account/services",
+            )
+        except CloudApiError as err:
+            raise AccountApiError(err, orig_exc=err) from err
+        return details

--- a/tests/test_account_api.py
+++ b/tests/test_account_api.py
@@ -79,9 +79,10 @@ async def test_problems_getting_services(
     assert log_msg in caplog.text
 
 
-@pytest.mark.parametrize("services_response", [
-    {"alexa": {"available": True}, "storage": {"available": False}}
-])
+@pytest.mark.parametrize(
+    "services_response",
+    [{"alexa": {"available": True}, "storage": {"available": False}}],
+)
 async def test_getting_services(
     aioclient_mock: AiohttpClientMocker,
     auth_cloud_mock: Cloud,

--- a/tests/test_account_api.py
+++ b/tests/test_account_api.py
@@ -1,0 +1,101 @@
+"""Tests for Instance API."""
+
+from typing import Any
+
+from aiohttp import ClientError
+import pytest
+
+from hass_nabucasa import Cloud
+from hass_nabucasa.account_api import (
+    AccountApi,
+    AccountApiError,
+    AccountServicesDetails,
+)
+from tests.utils.aiohttp import AiohttpClientMocker
+
+API_HOSTNAME = "example.com"
+
+
+@pytest.fixture(autouse=True)
+def set_hostname(auth_cloud_mock: Cloud):
+    """Set API hostname for the mock cloud service."""
+    auth_cloud_mock.servicehandlers_server = API_HOSTNAME
+
+
+@pytest.mark.parametrize(
+    "exception,getmockargs,log_msg,exception_msg",
+    [
+        [
+            AccountApiError,
+            {"status": 500, "text": "Internal Server Error"},
+            "Response for get from example.com/account/services (500)",
+            "Failed to parse API response",
+        ],
+        [
+            AccountApiError,
+            {"status": 429, "text": "Too fast"},
+            "Response for get from example.com/account/services (429)",
+            "Failed to parse API response",
+        ],
+        [
+            AccountApiError,
+            {"exc": TimeoutError()},
+            "",
+            "Timeout reached while calling API",
+        ],
+        [
+            AccountApiError,
+            {"exc": ClientError("boom!")},
+            "",
+            "Failed to fetch: boom!",
+        ],
+        [
+            AccountApiError,
+            {"exc": Exception("boom!")},
+            "",
+            "Unexpected error while calling API: boom!",
+        ],
+    ],
+)
+async def test_problems_getting_services(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    exception: Exception,
+    getmockargs: dict[str, Any],
+    log_msg: str,
+    exception_msg: str,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test problems getting account services."""
+    account_api = AccountApi(auth_cloud_mock)
+    aioclient_mock.get(
+        f"https://{API_HOSTNAME}/account/services",
+        **getmockargs,
+    )
+
+    with pytest.raises(exception, match=exception_msg):
+        await account_api.services()
+
+    assert log_msg in caplog.text
+
+
+@pytest.mark.parametrize("services_response", [
+    {"alexa": {"available": True}, "storage": {"available": False}}
+])
+async def test_getting_services(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    services_response: AccountServicesDetails,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test getting account services."""
+    account_api = AccountApi(auth_cloud_mock)
+    aioclient_mock.get(
+        f"https://{API_HOSTNAME}/account/services",
+        json=services_response,
+    )
+
+    services = await account_api.services()
+
+    assert services == services_response
+    assert "Response for get from example.com/account/services (200)" in caplog.text


### PR DESCRIPTION
Similar to https://github.com/NabuCasa/hass-nabucasa/pull/783

Add a new class to interact with the account part of the servicehandlers API.

This new class is initialized with the /services endpoint.