### PR TITLE
Add base64 md5 hash calculation to files

### DIFF
--- a/hass_nabucasa/files.py
+++ b/hass_nabucasa/files.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import base64
 from collections.abc import AsyncIterator, Callable, Coroutine
 from enum import StrEnum
+import hashlib
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -53,6 +55,27 @@ class StoredFile(TypedDict):
     Size: int
     LastModified: str
     Metadata: dict[str, Any]
+
+
+async def calculate_b64md5(
+    open_stream: Callable[[], Coroutine[Any, Any, AsyncIterator[bytes]]],
+    size: int,
+) -> str:
+    """Calculate the MD5 hash of a file.
+
+    Raises FilesError if the bytes read from the stream does not match the size.
+    """
+    file_hash = hashlib.md5()  # noqa: S324 Disable warning about using md5
+    bytes_read = 0
+    stream = await open_stream()
+    async for chunk in stream:
+        bytes_read += len(chunk)
+        file_hash.update(chunk)
+    if bytes_read != size:
+        raise FilesError(
+            f"Indicated size {size} does not match actual size {bytes_read}"
+        )
+    return base64.b64encode(file_hash.digest()).decode()
 
 
 class Files(ApiBase):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -502,6 +502,7 @@ async def aiter_from_iter(iterable: Iterable) -> AsyncIterator:
 
 async def test_calculate_b64md5():
     """Test calculating base64 md5 hash."""
+
     async def open_stream() -> AsyncIterator[bytes]:
         """Mock open stream."""
         return aiter_from_iter((b"backup", b"data"))


### PR DESCRIPTION
Add base64 md5 hash calculation to files

Rationale: This is a detail, and we should remove it from the cloud backup agent