### PR TITLE
Add missing async_timeout dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "acme==3.2.0",
     "aiohttp>=3.6.1",
+    "async_timeout>=4",
     "atomicwrites-homeassistant==1.4.1",
     "attrs>=19.3",
     "ciso8601>=2.3.0",


### PR DESCRIPTION
snitun 0.41.x removed async_timeout as dep, howver this lib did not explictly list it as a dep but
uses it