### PR TITLE
Add async_delete_repair_issue method to CloudClient

### DIFF
--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -140,3 +140,7 @@ class CloudClient(ABC):
         severity: Literal["error", "warning"] = "warning",
     ) -> None:
         """Create a repair issue."""
+
+    @abstractmethod
+    async def async_delete_repair_issue(self, identifier: str) -> None:
+        """Delete a repair issue."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -150,6 +150,13 @@ class MockClient(CloudClient):
             },
         )
 
+    async def async_delete_repair_issue(self, identifier: str) -> None:
+        """Delete a repair issue."""
+        issue = next(
+            issue for issue in self.mock_repairs if issue["identifier"] == identifier
+        )
+        self.mock_repairs.remove(issue)
+
 
 class MockAcme:
     """Mock AcmeHandler."""


### PR DESCRIPTION
For the planned reconnection repair issue, we want to delete it when we detect that it is solved.