### PR TITLE
Refactor cloudhooks to use ApiBase and add generate method for cloudhook details

### DIFF
--- a/hass_nabucasa/cloudhooks.py
+++ b/hass_nabucasa/cloudhooks.py
@@ -2,32 +2,49 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import async_timeout
 
-from . import cloud_api
+from .api import ApiBase, CloudApiError, api_exception_handler
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
 
 
-class Cloudhooks:
+class GeneratedCloudhookDetails(TypedDict):
+    """Details of a generated cloudhook."""
+
+    url: str
+    cloudhook_id: str
+
+
+class CloudhookApiError(CloudApiError):
+    """Error raised when a cloudhook API call fails."""
+
+
+class Cloudhooks(ApiBase):
     """Class to help manage cloudhooks."""
 
     def __init__(self, cloud: Cloud[_ClientT]) -> None:
         """Initialize cloudhooks."""
-        self.cloud = cloud
-
+        super().__init__(cloud)
         cloud.iot.register_on_connect(self.async_publish_cloudhooks)
+
+    @property
+    def hostname(self) -> str:
+        """Get the hostname."""
+        if TYPE_CHECKING:
+            assert self._cloud.cloudhook_server is not None
+        return self._cloud.cloudhook_server
 
     async def async_publish_cloudhooks(self) -> None:
         """Inform the Relayer of the cloudhooks that we support."""
-        if not self.cloud.is_connected:
+        if not self._cloud.is_connected:
             return
 
-        cloudhooks = self.cloud.client.cloudhooks
-        await self.cloud.iot.async_send_message(
+        cloudhooks = self._cloud.client.cloudhooks
+        await self._cloud.iot.async_send_message(
             "webhook-register",
             {"cloudhook_ids": [info["cloudhook_id"] for info in cloudhooks.values()]},
             expect_answer=False,
@@ -35,20 +52,18 @@ class Cloudhooks:
 
     async def async_create(self, webhook_id: str, managed: bool) -> dict[str, Any]:
         """Create a cloud webhook."""
-        cloudhooks = self.cloud.client.cloudhooks
+        cloudhooks = self._cloud.client.cloudhooks
 
         if webhook_id in cloudhooks:
             raise ValueError("Hook is already enabled for the cloud.")
 
-        if not self.cloud.iot.connected:
+        if not self._cloud.iot.connected:
             raise ValueError("Cloud is not connected")
 
         # Create cloud hook
         async with async_timeout.timeout(10):
-            resp = await cloud_api.async_create_cloudhook(self.cloud)
+            data = await self.generate()
 
-        resp.raise_for_status()
-        data = await resp.json()
         cloudhook_id = data["cloudhook_id"]
         cloudhook_url = data["url"]
 
@@ -60,14 +75,14 @@ class Cloudhooks:
             "cloudhook_url": cloudhook_url,
             "managed": managed,
         }
-        await self.cloud.client.async_cloudhooks_update(cloudhooks)
+        await self._cloud.client.async_cloudhooks_update(cloudhooks)
 
         await self.async_publish_cloudhooks()
         return hook
 
     async def async_delete(self, webhook_id: str) -> None:
         """Delete a cloud webhook."""
-        cloudhooks = self.cloud.client.cloudhooks
+        cloudhooks = self._cloud.client.cloudhooks
 
         if webhook_id not in cloudhooks:
             raise ValueError("Hook is not enabled for the cloud.")
@@ -75,6 +90,15 @@ class Cloudhooks:
         # Remove hook
         cloudhooks = dict(cloudhooks)
         cloudhooks.pop(webhook_id)
-        await self.cloud.client.async_cloudhooks_update(cloudhooks)
+        await self._cloud.client.async_cloudhooks_update(cloudhooks)
 
         await self.async_publish_cloudhooks()
+
+    @api_exception_handler(CloudhookApiError)
+    async def generate(self) -> GeneratedCloudhookDetails:
+        """Get the voice connection details."""
+        details: GeneratedCloudhookDetails = await self._call_cloud_api(
+            method="POST",
+            path="/generate",
+        )
+        return details

--- a/tests/test_cloudhooks.py
+++ b/tests/test_cloudhooks.py
@@ -35,9 +35,9 @@ async def test_enable(mock_cloudhooks, aioclient_mock):
 
     assert hook == await mock_cloudhooks.async_create("mock-webhook-id", False)
 
-    assert mock_cloudhooks.cloud.client.cloudhooks == {"mock-webhook-id": hook}
+    assert mock_cloudhooks._cloud.client.cloudhooks == {"mock-webhook-id": hook}
 
-    publish_calls = mock_cloudhooks.cloud.iot.async_send_message.mock_calls
+    publish_calls = mock_cloudhooks._cloud.iot.async_send_message.mock_calls
     assert len(publish_calls) == 1
     assert publish_calls[0][1][0] == "webhook-register"
     assert publish_calls[0][1][1] == {"cloudhook_ids": ["mock-cloud-id"]}
@@ -45,7 +45,7 @@ async def test_enable(mock_cloudhooks, aioclient_mock):
 
 async def test_disable(mock_cloudhooks):
     """Test disabling cloudhooks."""
-    mock_cloudhooks.cloud.client._cloudhooks = {
+    mock_cloudhooks._cloud.client._cloudhooks = {
         "mock-webhook-id": {
             "webhook_id": "mock-webhook-id",
             "cloudhook_id": "mock-cloud-id",
@@ -55,9 +55,9 @@ async def test_disable(mock_cloudhooks):
 
     await mock_cloudhooks.async_delete("mock-webhook-id")
 
-    assert mock_cloudhooks.cloud.client.cloudhooks == {}
+    assert mock_cloudhooks._cloud.client.cloudhooks == {}
 
-    publish_calls = mock_cloudhooks.cloud.iot.async_send_message.mock_calls
+    publish_calls = mock_cloudhooks._cloud.iot.async_send_message.mock_calls
     assert len(publish_calls) == 1
     assert publish_calls[0][1][0] == "webhook-register"
     assert publish_calls[0][1][1] == {"cloudhook_ids": []}
@@ -65,9 +65,9 @@ async def test_disable(mock_cloudhooks):
 
 async def test_create_without_connected(mock_cloudhooks, aioclient_mock):
     """Test we don't publish a hook if not connected."""
-    mock_cloudhooks.cloud.is_connected = False
+    mock_cloudhooks._cloud.is_connected = False
     # Make sure we fail test when we send a message.
-    mock_cloudhooks.cloud.iot.async_send_message.side_effect = ValueError
+    mock_cloudhooks._cloud.iot.async_send_message.side_effect = ValueError
 
     aioclient_mock.post(
         "https://webhook-create.url/generate",
@@ -86,6 +86,6 @@ async def test_create_without_connected(mock_cloudhooks, aioclient_mock):
 
     assert hook == await mock_cloudhooks.async_create("mock-webhook-id", True)
 
-    assert mock_cloudhooks.cloud.client.cloudhooks == {"mock-webhook-id": hook}
+    assert mock_cloudhooks._cloud.client.cloudhooks == {"mock-webhook-id": hook}
 
-    assert len(mock_cloudhooks.cloud.iot.async_send_message.mock_calls) == 0
+    assert len(mock_cloudhooks._cloud.iot.async_send_message.mock_calls) == 0


### PR DESCRIPTION
Follows the trend of dedicated classes for the API handling based on a shared API class.