### PR TITLE
Separate out connection errors from subscription issues

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -459,7 +459,7 @@ class Cloud(Generic[_ClientT]):
             _LOGGER.info(
                 err
                 if isinstance(err, ClientError)
-                else "Timeout error reached while getting subscripton information"
+                else "Timeout error reached while getting subscription information"
             )
             self.async_initialize_subscription_reconnection_handler(
                 SubscriptionReconnectionReason.CONNECTION_ERROR

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -488,7 +488,7 @@ class Cloud(Generic[_ClientT]):
             sub_expired = self.expiration_date
 
             if reason == SubscriptionReconnectionReason.CONNECTION_ERROR:
-                wait_hours = 1
+                wait_hours = 0.5
             elif sub_expired > (now_as_utc - timedelta(days=1)):
                 wait_hours = 3
             elif sub_expired > (now_as_utc - timedelta(days=7)):

--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -75,5 +75,6 @@ recreate it and notify you when it's available.
 class SubscriptionReconnectionReason(StrEnum):
     """Subscription reconnection reason."""
 
+    CONNECTION_ERROR = "connection_error"
     NO_SUBSCRIPTION = "no_subscription"
     SUBSCRIPTION_EXPIRED = "subscription_expired"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -525,7 +525,7 @@ async def test_subscription_reconnection_handler_connection_error(
             SubscriptionReconnectionReason.CONNECTION_ERROR
         )
 
-    # For connection errors, should wait 1 hours (60 minutes)
-    sleep_mock.assert_called_with(1 * 60 * 60)
+    # For connection errors, should wait 1800 seconds (30 minutes)
+    sleep_mock.assert_called_with(1_800)
     _initialize_mocker.assert_awaited_once()
     assert "Stopping subscription reconnection handler" in caplog.text


### PR DESCRIPTION
This pull request introduces enhancements to the subscription reconnection logic in the `hass_nabucasa` module, including improved handling of connection errors and more robust retry mechanisms. It also adds a new reconnection reason, `CONNECTION_ERROR`, and includes corresponding unit tests to validate the new functionality.

### Subscription Reconnection Enhancements:
* Introduced a new reconnection reason, `CONNECTION_ERROR`, to handle scenarios where connection failures occur during subscription validation. (`hass_nabucasa/const.py`, [hass_nabucasa/const.pyR78](diffhunk://#diff-73dd8795356720e0c7369f5e6b5cccfd744d9f4202ecde3927db81e9feede840R78))
* Added `_connection_retry_count` to track retry attempts and implemented exponential backoff with randomized intervals for connection error retries. (`hass_nabucasa/__init__.py`, [[1]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR98) [[2]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL483-R502)
* Updated logging to provide clearer information during connection error retries, including the retry attempt number and wait time. (`hass_nabucasa/__init__.py`, [hass_nabucasa/__init__.pyR517-R524](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR517-R524))

### Error Handling Improvements:
* Enhanced error handling in `async_subscription_is_valid` to catch `TimeoutError` and `ClientError` explicitly, log relevant details, and trigger reconnection logic when necessary. (`hass_nabucasa/__init__.py`, [hass_nabucasa/__init__.pyR456-R469](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR456-R469))
* Refined exception handling in `_async_get_billing_plan_type` to log warnings for `CloudError` while maintaining existing functionality. (`hass_nabucasa/__init__.py`, [hass_nabucasa/__init__.pyL470-R483](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL470-R483))

### Unit Tests:
* Added a new test, `test_subscription_reconnection_handler_connection_error`, to validate the behavior of the reconnection handler during connection errors, including retry logic and logging. (`tests/test_init.py`, [tests/test_init.pyR499-R536](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eR499-R536))