### PR TITLE
Remove cloud_api.async_subscription_info

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -19,7 +19,6 @@ from .account_api import AccountApi
 from .alexa_api import AlexaApi
 from .auth import CloudError, CognitoAuth
 from .client import CloudClient
-from .cloud_api import async_subscription_info
 from .cloudhooks import Cloudhooks
 from .const import (
     ACCOUNT_URL,
@@ -465,7 +464,7 @@ class Cloud(Generic[_ClientT]):
         billing_plan_type: str | None = None
         try:
             async with asyncio.timeout(30):
-                subscription = await async_subscription_info(self, True)
+                subscription = await self.payments.subscription_info(skip_renew=True)
             billing_plan_type = subscription.get("billing_plan_type")
         except (CloudError, TimeoutError, ClientError) as err:
             _LOGGER.warning("Could not get subscription info", exc_info=err)

--- a/hass_nabucasa/cloud_api.py
+++ b/hass_nabucasa/cloud_api.py
@@ -320,29 +320,6 @@ async def async_google_actions_request_sync(cloud: Cloud[_ClientT]) -> ClientRes
 
 
 @_check_token
-async def async_subscription_info(
-    cloud: Cloud[_ClientT], skip_renew: bool = False
-) -> dict[str, Any]:
-    """Fetch subscription info."""
-    if TYPE_CHECKING:
-        assert cloud.id_token is not None
-    resp = await cloud.websession.get(
-        f"https://{cloud.accounts_server}/payments/subscription_info",
-        headers={"authorization": cloud.id_token, USER_AGENT: cloud.client.client_name},
-    )
-    _do_log_response(resp)
-    resp.raise_for_status()
-    data: dict[str, Any] = await resp.json()
-
-    # If subscription info indicates we are subscribed, force a refresh of the token
-    if data.get("provider") and not cloud.started and not skip_renew:
-        _LOGGER.debug("Found disconnected account with valid subscription, connecting")
-        await cloud.auth.async_renew_access_token()
-
-    return data
-
-
-@_check_token
 async def async_migrate_paypal_agreement(cloud: Cloud[_ClientT]) -> dict[str, Any]:
     """Migrate a paypal agreement from legacy."""
     if TYPE_CHECKING:

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Generator
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 from aiohttp import ClientResponseError
 import pytest
@@ -105,54 +105,6 @@ async def test_get_access_token(auth_cloud_mock, aioclient_mock):
 
     await cloud_api.async_alexa_access_token(auth_cloud_mock)
     assert len(aioclient_mock.mock_calls) == 1
-
-
-async def test_subscription_info(auth_cloud_mock, aioclient_mock):
-    """Test fetching subscription info."""
-    aioclient_mock.get(
-        "https://example.com/payments/subscription_info",
-        json={
-            "success": True,
-            "provider": None,
-        },
-    )
-    auth_cloud_mock.id_token = "mock-id-token"
-    auth_cloud_mock.accounts_server = "example.com"
-
-    with patch.object(
-        auth_cloud_mock.auth,
-        "async_renew_access_token",
-        AsyncMock(),
-    ) as mock_renew:
-        data = await cloud_api.async_subscription_info(auth_cloud_mock)
-    assert len(aioclient_mock.mock_calls) == 1
-    assert data == {
-        "success": True,
-        "provider": None,
-    }
-
-    auth_cloud_mock.started = False
-    aioclient_mock.clear_requests()
-    aioclient_mock.get(
-        "https://example.com/payments/subscription_info",
-        json={
-            "success": True,
-            "provider": "mock-provider",
-        },
-    )
-    with patch.object(
-        auth_cloud_mock.auth,
-        "async_renew_access_token",
-        AsyncMock(),
-    ) as mock_renew:
-        data = await cloud_api.async_subscription_info(auth_cloud_mock)
-
-    assert len(aioclient_mock.mock_calls) == 1
-    assert data == {
-        "success": True,
-        "provider": "mock-provider",
-    }
-    assert len(mock_renew.mock_calls) == 1
 
 
 async def test_migrate_paypal_agreement(auth_cloud_mock, aioclient_mock):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -484,7 +484,7 @@ async def test_subscription_reconnect_for_no_subscription(
         ),
         patch("hass_nabucasa.asyncio.sleep", AsyncMock()),
         patch(
-            "hass_nabucasa.async_subscription_info",
+            "hass_nabucasa.PaymentsApi.subscription_info",
             side_effect=[
                 subscription_info_mock("no_subscription"),
                 subscription_info_mock("mock-plan"),


### PR DESCRIPTION
### Refactoring of subscription info retrieval:

* [`hass_nabucasa/__init__.py`](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL468-R467): Replaced the call to `async_subscription_info` with `self.payments.subscription_info` in `_async_get_billing_plan_type`. This change simplifies the code by using the `PaymentsApi` class directly.

* [`hass_nabucasa/cloud_api.py`](diffhunk://#diff-7466be7e0e33ce2250d83d0fe58edf40518150eb240fc8afd10802d1c0e20e98L322-L344): Removed the `async_subscription_info` function, consolidating its functionality into the `PaymentsApi.subscription_info` method.
