### PR TITLE
Add new NabuCasa* base exceptions

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -17,7 +17,7 @@ import jwt
 
 from .account_api import AccountApi
 from .alexa_api import AlexaApi
-from .auth import CloudError, CognitoAuth
+from .auth import CognitoAuth
 from .client import CloudClient
 from .cloud_api import async_subscription_info
 from .cloudhooks import Cloudhooks
@@ -29,6 +29,12 @@ from .const import (
     MODE_DEV,  # noqa: F401
     STATE_CONNECTED,
     SubscriptionReconnectionReason,
+)
+from .exceptions import (
+    CloudError,
+    NabuCasaAuthenticationError,
+    NabuCasaBaseError,
+    NabuCasaConnectionError,
 )
 from .files import Files
 from .google_report_state import GoogleReportState
@@ -43,6 +49,15 @@ from .remote import RemoteUI
 from .utils import UTC, gather_callbacks, parse_date, utcnow
 from .voice import Voice
 from .voice_api import VoiceApi
+
+__all__ = [
+    "AlreadyConnectedError",
+    "Cloud",
+    "CloudError",
+    "NabuCasaAuthenticationError",
+    "NabuCasaBaseError",
+    "NabuCasaConnectionError",
+]
 
 _ClientT = TypeVar("_ClientT", bound=CloudClient)
 

--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -18,7 +18,8 @@ from aiohttp import (
     hdrs,
 )
 
-from .auth import CloudError, Unauthenticated, UnknownError
+from .auth import Unauthenticated, UnknownError
+from .exceptions import CloudError
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT

--- a/hass_nabucasa/auth.py
+++ b/hass_nabucasa/auth.py
@@ -16,16 +16,13 @@ import pycognito
 from pycognito.exceptions import ForceChangePasswordException, MFAChallengeException
 
 from .const import MESSAGE_AUTH_FAIL
+from .exceptions import CloudError
 from .utils import expiration_from_token, utcnow
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class CloudError(Exception):
-    """Base class for cloud related errors."""
 
 
 class Unauthenticated(CloudError):

--- a/hass_nabucasa/exceptions.py
+++ b/hass_nabucasa/exceptions.py
@@ -1,0 +1,22 @@
+"""Custom base exceptions for the Nabu Casa integration."""
+from __future__ import annotations
+
+
+class NabuCasaBaseError(Exception):
+    """Base class for all Nabu Casa exceptions."""
+
+
+class NabuCasaConnectionError(NabuCasaBaseError):
+    """Base class for all Nabu Casa connection exceptions."""
+
+
+class NabuCasaAuthenticationError(NabuCasaBaseError):
+    """Base class for all Nabu Casa authentication exceptions."""
+
+
+class CloudError(NabuCasaBaseError):
+    """
+    Base class for all Nabu Casa cloud exceptions.
+
+    Kept for compatibility with existing code.
+    """

--- a/hass_nabucasa/iot_base.py
+++ b/hass_nabucasa/iot_base.py
@@ -21,7 +21,6 @@ from aiohttp import (
     hdrs,
 )
 
-from .auth import CloudError
 from .const import (
     MESSAGE_EXPIRATION,
     STATE_CONNECTED,
@@ -29,6 +28,7 @@ from .const import (
     STATE_DISCONNECTED,
     SubscriptionReconnectionReason,
 )
+from .exceptions import CloudError
 from .utils import gather_callbacks
 
 if TYPE_CHECKING:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 from pycognito.exceptions import MFAChallengeException
 import pytest
 
-from hass_nabucasa import auth as auth_api
+from hass_nabucasa import CloudError, auth as auth_api
 
 
 @pytest.fixture
@@ -163,7 +163,7 @@ async def test_register_fails(mock_cognito, cloud_mock):
     """Test registering an account."""
     mock_cognito.register.side_effect = aws_error("SomeError")
     auth = auth_api.CognitoAuth(cloud_mock)
-    with pytest.raises(auth_api.CloudError):
+    with pytest.raises(CloudError):
         await auth.async_register("email@home-assistant.io", "password")
 
 
@@ -178,7 +178,7 @@ async def test_resend_email_confirm_fails(mock_cognito, cloud_mock):
     """Test failure when starting forgot password flow."""
     auth = auth_api.CognitoAuth(cloud_mock)
     mock_cognito.client.resend_confirmation_code.side_effect = aws_error("SomeError")
-    with pytest.raises(auth_api.CloudError):
+    with pytest.raises(CloudError):
         await auth.async_resend_email_confirm("email@home-assistant.io")
 
 
@@ -193,7 +193,7 @@ async def test_forgot_password_fails(mock_cognito, cloud_mock):
     """Test failure when starting forgot password flow."""
     auth = auth_api.CognitoAuth(cloud_mock)
     mock_cognito.initiate_forgot_password.side_effect = aws_error("SomeError")
-    with pytest.raises(auth_api.CloudError):
+    with pytest.raises(CloudError):
         await auth.async_forgot_password("email@home-assistant.io")
 
 
@@ -230,7 +230,7 @@ async def test_check_token_raises(mock_cognito, cloud_mock):
     mock_cognito.renew_access_token.side_effect = aws_error("SomeError")
     auth = auth_api.CognitoAuth(cloud_mock)
 
-    with pytest.raises(auth_api.CloudError):
+    with pytest.raises(CloudError):
         await auth.async_check_token()
 
     assert len(mock_cognito.check_token.mock_calls) == 2

--- a/tests/test_iot_base.py
+++ b/tests/test_iot_base.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 from aiohttp import WSMessage, WSMsgType, client_exceptions
 import pytest
 
-from hass_nabucasa import auth as auth_api, iot_base
+from hass_nabucasa import CloudError, iot_base
 
 
 class MockIoT(iot_base.BaseIoT):
@@ -148,7 +148,7 @@ async def test_cloud_sending_invalid_json(mock_iot_client, caplog, cloud_mock_io
 async def test_cloud_check_token_raising(mock_iot_client, caplog, cloud_mock_iot):
     """Test cloud unable to check token."""
     conn = MockIoT(cloud_mock_iot)
-    cloud_mock_iot.auth.async_check_token.side_effect = auth_api.CloudError("BLA")
+    cloud_mock_iot.auth.async_check_token.side_effect = CloudError("BLA")
 
     await conn.connect()
 


### PR DESCRIPTION
This pull request refactors the exception handling in the `hass_nabucasa` package by introducing a new `exceptions.py` module to centralize custom exceptions. It also updates references to the `CloudError` exception across multiple files and tests for improved code organization and compatibility.

### Refactoring of exception handling:

* [`hass_nabucasa/exceptions.py`](diffhunk://#diff-a204edf7a818cc01d4f05aca98b39d1f0bc8513b2e1c4e88ec76a3f2905b7d7fR1-R22): Introduced a new module defining base exceptions (`NabuCasaBaseError`, `NabuCasaConnectionError`, `NabuCasaAuthenticationError`) and retained `CloudError` for backward compatibility.
* [`hass_nabucasa/auth.py`](diffhunk://#diff-6ac8aef9770cd86a0c143318507be32a32ff6c501a4fa1e0def12f2f9a73a5d1R19): Removed the local definition of `CloudError` and imported it from the new `exceptions.py` module. [[1]](diffhunk://#diff-6ac8aef9770cd86a0c143318507be32a32ff6c501a4fa1e0def12f2f9a73a5d1R19) [[2]](diffhunk://#diff-6ac8aef9770cd86a0c143318507be32a32ff6c501a4fa1e0def12f2f9a73a5d1L27-L30)

### Updates to imports and references:

* [`hass_nabucasa/__init__.py`](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL20-R20): Updated imports to include exceptions from the new `exceptions.py` module and added them to `__all__` for export. [[1]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL20-R20) [[2]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR33-R38) [[3]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR53-R61)
* Other modules (`hass_nabucasa/api.py`, `hass_nabucasa/iot_base.py`): Replaced references to `CloudError` from `auth.py` with imports from the new `exceptions.py` module. [[1]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354L21-R22) [[2]](diffhunk://#diff-5e3355d83e7cccc0cac0abf7827fbde73bbaf0300df351611d30b903f0974b53L24-R31)

### Updates to tests:

* [`tests/test_auth.py`](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L10-R10): Updated test cases to reference `CloudError` from the new `exceptions.py` module instead of `auth.py`. [[1]](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L10-R10) [[2]](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L166-R166) [[3]](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L181-R181) [[4]](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L196-R196) [[5]](diffhunk://#diff-a99307c61c3c55875b5bb65e0b045ccd074e277afe3cca9665e7dbd33023daf9L233-R233)
* [`tests/test_iot_base.py`](diffhunk://#diff-993504f4bbdcbd5559b99503bd33e945c24f58a38927df55c6ea949609e91617L8-R8): Adjusted test cases to use the updated `CloudError` import. [[1]](diffhunk://#diff-993504f4bbdcbd5559b99503bd33e945c24f58a38927df55c6ea949609e91617L8-R8) [[2]](diffhunk://#diff-993504f4bbdcbd5559b99503bd33e945c24f58a38927df55c6ea949609e91617L151-R151)