### PR TITLE
Add freezegun for time manipulation in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ version = "0.0.0"
 [project.optional-dependencies]
 test = [
     "codespell==2.4.1",
+    "freezegun==1.5.2",
     "mypy==1.16.1",
     "pre-commit==4.2.0",
     "pre-commit-hooks==5.0.0",
@@ -128,6 +129,7 @@ reports=false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+timeout = 5
 
 [tool.ruff]
 fix = true

--- a/tests/common.py
+++ b/tests/common.py
@@ -11,6 +11,8 @@ from unittest.mock import Mock
 
 from hass_nabucasa.client import CloudClient
 
+FROZEN_NOW_AS_TIMESTAMP = 1537185600  # 2018-09-17 12:00:00 UTC
+
 
 class MockClient(CloudClient):
     """Interface class for Home Assistant."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,20 @@ from typing import cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiohttp import web
+from freezegun import freeze_time
 import pytest
 
 from .common import MockClient
 from .utils.aiohttp import mock_aiohttp_client
 
 logging.basicConfig(level=logging.DEBUG)
+
+
+@pytest.fixture(autouse=True)
+def freeze_time_fixture():
+    """Freeze time for all tests by default."""
+    with freeze_time("2018-09-17 12:00:00", tick=True):
+        yield
 
 
 @pytest.fixture(name="loop")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,6 +8,7 @@ from pycognito.exceptions import MFAChallengeException
 import pytest
 
 from hass_nabucasa import auth as auth_api
+from tests.common import FROZEN_NOW_AS_TIMESTAMP
 
 
 @pytest.fixture
@@ -303,7 +304,6 @@ async def test_sleep_time_calculation(
     auth = auth_api.CognitoAuth(mock_cloud)
 
     with (
-        patch("hass_nabucasa.auth.utcnow") as mock_utcnow,
         patch("hass_nabucasa.auth.expiration_from_token") as mock_exp,
         patch("hass_nabucasa.auth.asyncio.sleep", AsyncMock()),
         patch(
@@ -312,8 +312,9 @@ async def test_sleep_time_calculation(
         ),
         patch("random.randint") as mock_random,
     ):
-        mock_utcnow.return_value.timestamp.return_value = 1000000  # Mock current time
-        mock_exp.return_value = 1000000 + exp_value if exp_value else None
+        mock_exp.return_value = (
+            FROZEN_NOW_AS_TIMESTAMP + exp_value if exp_value else None
+        )
         mock_random.return_value = random_value
 
         await auth._async_handle_token_refresh()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 import json
 from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
+from freezegun import freeze_time
 import pytest
 
 import hass_nabucasa as cloud
@@ -280,58 +281,31 @@ def test_write_user_info(cl: cloud.Cloud):
 
 def test_subscription_expired(cl: cloud.Cloud):
     """Test subscription being expired after 3 days of expiration."""
-    token_val = {"custom:sub-exp": "2017-11-13"}
+    token_val = {"custom:sub-exp": "2018-09-17"}
+
     with (
         patch.object(cl, "_decode_claims", return_value=token_val),
-        patch(
-            "hass_nabucasa.utcnow",
-            return_value=utcnow().replace(year=2017, month=11, day=13),
-        ),
     ):
         assert not cl.subscription_expired
 
     with (
         patch.object(cl, "_decode_claims", return_value=token_val),
-        patch(
-            "hass_nabucasa.utcnow",
-            return_value=utcnow().replace(
-                year=2017,
-                month=11,
-                day=19,
-                hour=23,
-                minute=59,
-                second=59,
-            ),
-        ),
+        freeze_time("2018-09-23 23:59:59"),
     ):
         assert not cl.subscription_expired
 
     with (
         patch.object(cl, "_decode_claims", return_value=token_val),
-        patch(
-            "hass_nabucasa.utcnow",
-            return_value=utcnow().replace(
-                year=2017,
-                month=11,
-                day=20,
-                hour=0,
-                minute=0,
-                second=0,
-            ),
-        ),
+        freeze_time("2018-09-24 00:00:01"),
     ):
         assert cl.subscription_expired
 
 
 def test_subscription_not_expired(cl: cloud.Cloud):
     """Test subscription not being expired."""
-    token_val = {"custom:sub-exp": "2017-11-13"}
+    token_val = {"custom:sub-exp": "2018-09-19"}
     with (
         patch.object(cl, "_decode_claims", return_value=token_val),
-        patch(
-            "hass_nabucasa.utcnow",
-            return_value=utcnow().replace(year=2017, month=11, day=9),
-        ),
     ):
         assert not cl.subscription_expired
 


### PR DESCRIPTION
This pull request introduces enhancements to testing infrastructure and dependency management. Key changes include adding the `freezegun` library for time manipulation in tests, refactoring tests to use consistent time freezing, and improving test reliability by mocking timing functions.

### Dependency Management:

* Added `freezegun==1.5.2` to `pyproject.toml` under optional test dependencies for time manipulation in tests.
* Added a default timeout of 5 seconds for pytest configuration in `pyproject.toml`.

### Time-Freezing in Tests:

* Introduced `FROZEN_NOW_AS_TIMESTAMP` constant in `tests/common.py` to represent a fixed timestamp for tests.
* Added a `freeze_time_fixture` pytest fixture in `tests/conftest.py` to automatically freeze time for all tests at `2018-09-17 12:00:00 UTC`.

### Test Refactoring:

* Updated `tests/test_auth.py` to use `FROZEN_NOW_AS_TIMESTAMP` for token expiration calculations, replacing direct mocking of `utcnow`.
* Refactored `tests/test_init.py` to replace `utcnow` mocking with `freeze_time` for subscription expiration tests, improving readability and consistency.

### Timing Mocking for Reliability:

* Added a `mock_timing` fixture in `tests/test_remote.py` to mock timing functions like `asyncio.sleep` and `random.randint`, ensuring consistent and reliable test behavior. This fixture was applied across multiple test cases for backend initialization, certificate handling, and DNS configuration. [[1]](diffhunk://#diff-08c6f4bd38a94fbea8a7f0162636d38494862d12cda19b0716771836002797e5R33-R52) [[2]](diffhunk://#diff-08c6f4bd38a94fbea8a7f0162636d38494862d12cda19b0716771836002797e5R100) [[3]](diffhunk://#diff-08c6f4bd38a94fbea8a7f0162636d38494862d12cda19b0716771836002797e5R1108)