### PR TITLE
Implement better certificate management status updates

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -35,6 +35,7 @@ from .const import (
     DEFAULT_VALUES,
     MODE_DEV,  # noqa: F401
     STATE_CONNECTED,
+    CertificateStatus,
     SubscriptionReconnectionReason,
 )
 from .exceptions import (
@@ -58,6 +59,7 @@ __all__ = [
     "AccountApiError",
     "AlexaApiError",
     "AlreadyConnectedError",
+    "CertificateStatus",
     "Cloud",
     "CloudApiClientError",
     "CloudApiCodedError",

--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -17,6 +17,7 @@ STATE_CONNECTING = "connecting"
 STATE_CONNECTED = "connected"
 STATE_DISCONNECTED = "disconnected"
 
+DISPATCH_CERTIFICATE_STATUS = "certificate_status"
 DISPATCH_REMOTE_CONNECT = "remote_connect"
 DISPATCH_REMOTE_DISCONNECT = "remote_disconnect"
 DISPATCH_REMOTE_BACKEND_UP = "remote_backend_up"
@@ -70,6 +71,44 @@ MESSAGE_LOAD_CERTIFICATE_FAILURE = """
 Unable to load the certificate. We will automatically
 recreate it and notify you when it's available.
 """
+
+
+class CertificateStatus(StrEnum):
+    """Representation of the certificate status."""
+
+    ACME_ACCOUNT_CREATED = "acme_account_created"
+    ACME_ACCOUNT_CREATING = "acme_account_creating"
+    CERTIFICATE_FINALIZATION_FAILED = "certificate_finalization_failed"
+    CERTIFICATE_FINALIZING = "certificate_finalizing"
+    CERTIFICATE_LOAD_ERROR = "certificate_load_error"
+    CHALLENGE_ANSWER_FAILED = "challenge_answer_failed"
+    CHALLENGE_ANSWERED = "challenge_answered"
+    CHALLENGE_ANSWERING = "challenge_answering"
+    CHALLENGE_CLEANUP = "challenge_cleanup"
+    CHALLENGE_CREATED = "challenge_created"
+    CHALLENGE_DNS_FAILED = "challenge_dns_failed"
+    CHALLENGE_DNS_PROPAGATING = "challenge_dns_propagating"
+    CHALLENGE_DNS_UPDATED = "challenge_dns_updated"
+    CHALLENGE_DNS_UPDATING = "challenge_dns_updating"
+    CHALLENGE_PENDING = "challenge_pending"
+    CHALLENGE_UNEXPECTED_ERROR = "challenge_unexpected_error"
+    CSR_GENERATING = "csr_generating"
+    DOMAIN_VALIDATION_FAILED = "domain_validation_failed"
+    ERROR = "error"
+    EXPIRED = "expired"
+    EXPIRING_SOON = "expiring_soon"
+    GENERATING = "generating"
+    INITIAL_CERT_ERROR = "initial_cert_error"
+    INITIAL_GENERATING = "initial_generating"
+    INITIAL_LOADED = "initial_loaded"
+    LOADED = "loaded"
+    LOADING = "loading"
+    READY = "ready"
+    RENEWAL_FAILED = "renewal_failed"
+    RENEWAL_GENERATING = "renewal_generating"
+    RENEWAL_LOADED = "renewal_loaded"
+    SSL_CONTEXT_ERROR = "ssl_context_error"
+    VALIDATING = "validating"
 
 
 class SubscriptionReconnectionReason(StrEnum):

--- a/hass_nabucasa/const.py
+++ b/hass_nabucasa/const.py
@@ -103,6 +103,7 @@ class CertificateStatus(StrEnum):
     INITIAL_LOADED = "initial_loaded"
     LOADED = "loaded"
     LOADING = "loading"
+    NO_CERTIFICATE = "no_certificate"
     READY = "ready"
     RENEWAL_FAILED = "renewal_failed"
     RENEWAL_GENERATING = "renewal_generating"

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -616,15 +616,14 @@ class RemoteUI:
             self._update_certificate_status(CertificateStatus.NO_CERTIFICATE)
             return True
 
-        if self._acme.expire_date is None or self._acme.expire_date <= utils.utcnow():
+        utcnow = utils.utcnow()
+
+        if self._acme.expire_date is None or self._acme.expire_date <= utcnow:
             self._update_certificate_status(CertificateStatus.EXPIRED)
             return True
 
         # Check if certificate is expiring soon
-        if not (
-            self._acme.expire_date
-            <= (utils.utcnow() + timedelta(days=RENEW_IF_EXPIRES_DAYS))
-        ):
+        if self._acme.expire_date > (utcnow + timedelta(days=RENEW_IF_EXPIRES_DAYS)):
             return False
 
         self._update_certificate_status(CertificateStatus.EXPIRING_SOON)

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -541,6 +541,7 @@ class RemoteUI:
 
                 # Renew certificate?
                 if not await self._should_renew_certificates():
+                    self._update_certificate_status(CertificateStatus.READY)
                     continue
 
                 # Renew certificate

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -612,12 +612,11 @@ class RemoteUI:
             assert self._acme is not None
             assert self.instance_domain is not None
 
-        # Check if certificate needs renewal due to availability or expiration
-        if (
-            not self._acme.certificate_available
-            or self._acme.expire_date is None
-            or self._acme.expire_date <= utils.utcnow()
-        ):
+        if not self._acme.certificate_available:
+            self._update_certificate_status(CertificateStatus.NO_CERTIFICATE)
+            return True
+
+        if self._acme.expire_date is None or self._acme.expire_date <= utils.utcnow():
             self._update_certificate_status(CertificateStatus.EXPIRED)
             return True
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -214,9 +214,10 @@ class MockAcme:
         """Hardening files."""
         self.call_hardening = True
 
-    def __call__(self, *args) -> MockAcme:
+    def __call__(self, *args, **kwargs) -> MockAcme:
         """Init."""
         self.init_args = args
+        self.init_kwargs = kwargs
         return self
 
 

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -3,7 +3,7 @@
 import asyncio
 from datetime import timedelta
 from ssl import SSLError
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from acme import client, messages
 import pytest
@@ -11,15 +11,16 @@ import pytest
 from hass_nabucasa import utils
 from hass_nabucasa.acme import AcmeHandler
 from hass_nabucasa.const import (
+    DISPATCH_CERTIFICATE_STATUS,
     DISPATCH_REMOTE_BACKEND_DOWN,
     DISPATCH_REMOTE_BACKEND_UP,
     DISPATCH_REMOTE_CONNECT,
     DISPATCH_REMOTE_DISCONNECT,
+    CertificateStatus,
 )
 from hass_nabucasa.remote import (
     RENEW_IF_EXPIRES_DAYS,
     WARN_RENEW_FAILED_DAYS,
-    CertificateStatus,
     RemoteUI,
     SubscriptionExpired,
 )
@@ -135,8 +136,23 @@ async def test_load_backend_exists_cert(
     assert remote._acme_task
     assert remote._reconnect_task
 
-    assert auth_cloud_mock.client.mock_dispatcher[0][0] == DISPATCH_REMOTE_BACKEND_UP
-    assert auth_cloud_mock.client.mock_dispatcher[1][0] == DISPATCH_REMOTE_CONNECT
+    # Check that certificate status updates were dispatched
+    certificate_dispatches = [
+        call
+        for call in auth_cloud_mock.client.mock_dispatcher
+        if call[0] == DISPATCH_CERTIFICATE_STATUS
+    ]
+    # Should have certificate status updates
+    assert len(certificate_dispatches) >= 1
+
+    # Check that backend and connection dispatches happened
+    backend_dispatches = [
+        call
+        for call in auth_cloud_mock.client.mock_dispatcher
+        if call[0] in (DISPATCH_REMOTE_BACKEND_UP, DISPATCH_REMOTE_CONNECT)
+    ]
+    assert any(call[0] == DISPATCH_REMOTE_BACKEND_UP for call in backend_dispatches)
+    assert any(call[0] == DISPATCH_REMOTE_CONNECT for call in backend_dispatches)
 
     await remote.stop()
     await asyncio.sleep(0.1)
@@ -1037,14 +1053,14 @@ async def test_acme_client_new_order_errors(
 
     with patch(
         "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc"),
+        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc", Mock()),
     ):
         assert remote._certificate_status is None
         await remote.load_backend()
 
     await asyncio.sleep(0.1)
     assert remote._acme.call_reset == should_reset
-    assert remote._certificate_status is CertificateStatus.ERROR
+    assert remote._certificate_status is CertificateStatus.INITIAL_CERT_ERROR
 
     await remote.stop()
 
@@ -1097,6 +1113,36 @@ async def test_context_error_handling(
 
     await asyncio.sleep(0.1)
     assert remote._acme.call_reset == should_reset
-    assert remote._certificate_status is CertificateStatus.ERROR
+    assert remote._certificate_status is CertificateStatus.SSL_CONTEXT_ERROR
 
     await remote.stop()
+
+
+async def test_certificate_status_dispatcher(auth_cloud_mock):
+    """Test certificate status dispatcher functionality."""
+    remote = RemoteUI(auth_cloud_mock)
+
+    # Test status update dispatching
+    remote._update_certificate_status(CertificateStatus.LOADING)
+
+    # Check that dispatcher was called
+    assert len(auth_cloud_mock.client.mock_dispatcher) == 1
+    assert auth_cloud_mock.client.mock_dispatcher[0] == (
+        DISPATCH_CERTIFICATE_STATUS,
+        CertificateStatus.LOADING,
+    )
+
+    # Test second status update
+    remote._update_certificate_status(CertificateStatus.ERROR)
+
+    assert len(auth_cloud_mock.client.mock_dispatcher) == 2
+    assert auth_cloud_mock.client.mock_dispatcher[1] == (
+        DISPATCH_CERTIFICATE_STATUS,
+        CertificateStatus.ERROR,
+    )
+
+    # Test duplicate status update (should be ignored)
+    remote._update_certificate_status(CertificateStatus.ERROR)
+
+    # Should still be 2 calls since status didn't change
+    assert len(auth_cloud_mock.client.mock_dispatcher) == 2


### PR DESCRIPTION
This PR adds more granularity in certificate statuses and sends these over the existing dispatcher.
The dispatched message can, if they choose it, be forwarded to the frontend for better context there, but. As-is, it would help a lot during troubleshooting, separated separations and logs.

<details>
<summary>Example logs</summary>

```
2025-07-09 06:54:22.336 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: loading
2025-07-09 06:54:22.341 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: validating
2025-07-09 06:54:22.341 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: no_certificate
2025-07-09 06:54:22.341 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: initial_generating
2025-07-09 06:54:22.342 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: acme_account_creating
2025-07-09 06:54:22.930 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: acme_account_created
2025-07-09 06:54:22.930 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: csr_generating
2025-07-09 06:54:23.032 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_pending
2025-07-09 06:54:23.555 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_created
2025-07-09 06:54:23.558 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_dns_updating
2025-07-09 06:54:24.446 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_dns_updated
2025-07-09 06:54:24.446 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_dns_propagating
2025-07-09 06:55:24.454 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_answering
2025-07-09 06:55:24.639 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_answered
2025-07-09 06:55:24.640 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: challenge_cleanup
2025-07-09 06:55:25.629 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: certificate_finalizing
2025-07-09 06:55:31.671 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: loading
2025-07-09 06:55:31.672 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: loaded
2025-07-09 06:55:31.672 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: initial_loaded
2025-07-09 06:55:31.674 DEBUG (MainThread) [hass_nabucasa.remote] Certificate status: ready
```

</details>