### PR TITLE
Allow empty API responses for POST and HEAD

### DIFF
--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+ALLOW_EMPTY_RESPONSE = frozenset(
+    {
+        "DELETE",
+        "POST",
+        "HEAD",
+    }
+)
+
 
 def api_exception_handler(
     exception: type[CloudApiError],
@@ -234,7 +242,7 @@ class ApiBase(ABC):
 
         self._do_log_response(resp, data)
 
-        if data is None and resp.method.upper() != "DELETE":
+        if data is None and resp.method.upper() not in ALLOW_EMPTY_RESPONSE:
             raise CloudApiError("Failed to parse API response") from None
 
         if (

--- a/tests/test_alexa_api.py
+++ b/tests/test_alexa_api.py
@@ -31,13 +31,13 @@ def set_hostname(auth_cloud_mock):
             AlexaApiError,
             {"status": 500, "text": "Internal Server Error"},
             "Response for post from example.com/alexa/access_token (500)",
-            "Failed to parse API response",
+            "Failed to fetch: (500) ",
         ],
         [
             AlexaApiError,
             {"status": 429, "text": "Too fast"},
             "Response for post from example.com/alexa/access_token (429)",
-            "Failed to parse API response",
+            "Failed to fetch: (429) ",
         ],
         [
             AlexaApiError,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
 from hass_nabucasa.api import (
+    ALLOW_EMPTY_RESPONSE,
+    ApiBase,
     CloudApiError,
     CloudApiNonRetryableError,
     api_exception_handler,
 )
+
+if TYPE_CHECKING:
+    from hass_nabucasa import Cloud
+    from tests.utils.aiohttp import AiohttpClientMocker
 
 
 class CustomException(CloudApiError):
@@ -33,3 +41,66 @@ async def test_raising_exception(exception, expected) -> None:
 
     with pytest.raises(expected):
         await mock_func()
+
+
+class TestApi(ApiBase):
+    """Test API implementation."""
+
+    @property
+    def hostname(self) -> str:
+        """Get the hostname."""
+        return "example.com"
+
+
+@pytest.mark.parametrize(
+    "method",
+    ALLOW_EMPTY_RESPONSE,
+)
+async def test_empty_response_handling_allowed_methods(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    method: str,
+) -> None:
+    """Test empty response handling for methods that allow empty responses."""
+    test_api = TestApi(auth_cloud_mock)
+
+    aioclient_mock.request(
+        method.lower(),
+        "https://example.com/test",
+        text="",
+        status=200,
+    )
+
+    result = await test_api._call_cloud_api(
+        path="/test",
+        method=method,
+        skip_token_check=True,
+    )
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["GET", "PUT", "PATCH", "OPTIONS"],
+)
+async def test_empty_response_handling_disallowed_methods(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    method: str,
+) -> None:
+    """Test empty response handling for methods that disallow empty responses."""
+    test_api = TestApi(auth_cloud_mock)
+
+    aioclient_mock.request(
+        method.lower(),
+        "https://example.com/test",
+        text="",
+        status=200,
+    )
+
+    with pytest.raises(CloudApiError, match="Failed to parse API response"):
+        await test_api._call_cloud_api(
+            path="/test",
+            method=method,
+            skip_token_check=True,
+        )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -43,7 +43,7 @@ async def test_raising_exception(exception, expected) -> None:
         await mock_func()
 
 
-class TestApi(ApiBase):
+class AwesomeApiClass(ApiBase):
     """Test API implementation."""
 
     @property
@@ -62,7 +62,7 @@ async def test_empty_response_handling_allowed_methods(
     method: str,
 ) -> None:
     """Test empty response handling for methods that allow empty responses."""
-    test_api = TestApi(auth_cloud_mock)
+    test_api = AwesomeApiClass(auth_cloud_mock)
 
     aioclient_mock.request(
         method.lower(),
@@ -89,7 +89,7 @@ async def test_empty_response_handling_disallowed_methods(
     method: str,
 ) -> None:
     """Test empty response handling for methods that disallow empty responses."""
-    test_api = TestApi(auth_cloud_mock)
+    test_api = AwesomeApiClass(auth_cloud_mock)
 
     aioclient_mock.request(
         method.lower(),

--- a/tests/test_payments_api.py
+++ b/tests/test_payments_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
@@ -149,14 +150,14 @@ async def test_trigger_async_renew_access_token(
             {"status": 500, "text": "Internal Server Error"},
             "Response for post from "
             "example.com/payments/migrate_paypal_agreement (500)",
-            "Failed to parse API response",
+            "Failed to fetch: (500) ",
         ],
         [
             PaymentsApiError,
             {"status": 429, "text": "Too fast"},
             "Response for post from "
             "example.com/payments/migrate_paypal_agreement (429)",
-            "Failed to parse API response",
+            "Failed to fetch: (429) ",
         ],
         [
             PaymentsApiError,
@@ -194,7 +195,7 @@ async def test_problems_migrating_paypal_agreement(
         **postmockargs,
     )
 
-    with pytest.raises(exception, match=exception_msg):
+    with pytest.raises(exception, match=re.escape(exception_msg)):
         await payments_api.migrate_paypal_agreement()
 
     if log_msg:


### PR DESCRIPTION
This pull request introduces improvements to the handling of empty API responses and refines error messages across the codebase. The changes include defining a set of HTTP methods that allow empty responses, updating the logic to handle these cases, and adding new tests to ensure the correctness of these updates.

### Improvements to API response handling:

* [`hass_nabucasa/api.py`](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R32-R39): Added `ALLOW_EMPTY_RESPONSE`, a frozenset of HTTP methods (`DELETE`, `POST`, `HEAD`) that allow empty responses, and updated `_call_cloud_api` to check against this set instead of hardcoding the "DELETE" method. [[1]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R32-R39) [[2]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354L237-R245)
