### PR TITLE
Suppress ContentTypeError in API handler

### DIFF
--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -15,6 +15,7 @@ from aiohttp import (
     ClientResponse,
     ClientResponseError,
     ClientTimeout,
+    ContentTypeError,
     hdrs,
 )
 
@@ -237,7 +238,7 @@ class ApiBase(ABC):
         )
 
         if resp.status < 500:
-            with contextlib.suppress(JSONDecodeError):
+            with contextlib.suppress(ContentTypeError, JSONDecodeError):
                 data = await resp.json()
 
         self._do_log_response(resp, data)


### PR DESCRIPTION
This pull request introduces a minor update to the `hass_nabucasa/api.py` file to improve error handling when decoding JSON responses from the cloud API.

Error handling enhancement:

* [`hass_nabucasa/api.py`](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R18): Added `ContentTypeError` to the list of imported exceptions and updated the `_call_cloud_api` method to suppress `ContentTypeError` alongside `JSONDecodeError` while decoding the response. [[1]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R18) [[2]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354L240-R241)