### PR TITLE
Refactor billing plan type retrieval to improve error handling

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -12,7 +12,7 @@ import random
 import shutil
 from typing import Any, Generic, Literal, TypeVar
 
-from aiohttp import ClientError, ClientSession
+from aiohttp import ClientSession
 from atomicwrites import atomic_write
 import jwt
 


### PR DESCRIPTION
This pull request refactors the `async_subscription_is_valid` method in `hass_nabucasa/__init__.py` to improve error handling and remove redundant code. Additionally, it updates the `_subscription_reconnection_handler` method to enhance logging precision.

### Refactoring and Error Handling Improvements:

* [`async_subscription_is_valid`](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR490-R504): Refactored to inline the `billing_plan_type` retrieval logic, removing the `_async_get_billing_plan_type` method. Improved error handling by introducing specific exception types (`CloudApiError`, `NabuCasaBaseError`) and using `asyncio.timeout` for better timeout management. Logging was adjusted to use `debug` level for subscription validation failures. [[1]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccR490-R504) [[2]](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL510-L520)

### Logging Enhancements:

* [`_subscription_reconnection_handler`](diffhunk://#diff-d0cce2ce4cffe95d8eef1517729f01295ed01af545f4a8d8f46edb47e3d89cccL556-R548): Updated logging to use `round` for more precise representation of wait times in minutes.