### PR TITLE
Add process_tts_stream for voice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "snitun==0.40.0",
     "webrtc-models<1.0.0",
     "yarl>=1.20,<2",
+    "sentence-stream==1.0.0",
 ]
 description = "Home Assistant cloud integration by Nabu Casa, Inc."
 license = {text = "GPL v3"}

--- a/tests/__snapshots__/test_voice.ambr
+++ b/tests/__snapshots__/test_voice.ambr
@@ -7,7 +7,7 @@
       '@xmlns': 'http://www.w3.org/2001/10/synthesis',
       '@xmlns:mstts': 'https://www.w3.org/2001/mstts',
       'voice': dict({
-        '#text': 'Text for Saying.',
+        '#text': 'Text for Saying. More Text for saying.',
         '@name': 'nl-NL-FennaNeural',
       }),
     }),

--- a/tests/__snapshots__/test_voice.ambr
+++ b/tests/__snapshots__/test_voice.ambr
@@ -1,4 +1,18 @@
 # serializer version: 1
+# name: test_process_tts_stream_with_voice
+  dict({
+    'speak': dict({
+      '@version': '1.0',
+      '@xml:lang': 'nl-NL',
+      '@xmlns': 'http://www.w3.org/2001/10/synthesis',
+      '@xmlns:mstts': 'https://www.w3.org/2001/mstts',
+      'voice': dict({
+        '#text': 'Text for Saying.',
+        '@name': 'nl-NL-FennaNeural',
+      }),
+    }),
+  })
+# ---
 # name: test_process_tts_with_gender
   dict({
     'speak': dict({

--- a/tests/test_voice.py
+++ b/tests/test_voice.py
@@ -167,7 +167,7 @@ async def test_process_tts_stream_with_voice(voice_api, aioclient_mock, snapshot
             assert wav_reader.getnframes() == 0  # streaming
 
         audio_bytes = result[44:]  # skip header
-        assert audio_bytes == b"My soundMy sound"  # 2 sentences
+        assert audio_bytes == b"My sound"  # 2 sentences processed together
 
     assert aioclient_mock.mock_calls[1][3] == {
         "Authorization": "Bearer test-key",


### PR DESCRIPTION
Uses [sentence-stream](https://github.com/OHF-Voice/sentence-stream) library directly to do sentence-based text-to-speech streaming.
Adds a new `process_tts_stream` function to voice that mirrors the TTS API in core: text chunks in, audio chunks out.
Needed for PR: https://github.com/home-assistant/core/pull/148925