### PR TITLE
Add pre-request logging for API calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "snitun==0.40.0",
     "webrtc-models<1.0.0",
+    "yarl>=1.20,<2",
 ]
 description = "Home Assistant cloud integration by Nabu Casa, Inc."
 license = {text = "GPL v3"}


### PR DESCRIPTION
Example:
```
2025-07-18 09:05:35.172 DEBUG (MainThread) [hass_nabucasa.api] Sending GET request to accounts-e5xc.dev.nabucasa.com/payments/subscription_info
2025-07-18 09:05:35.946 DEBUG (MainThread) [hass_nabucasa.api] Response for GET from accounts-e5xc.dev.nabucasa.com/payments/subscription_info (200) 
```