### PR TITLE
Move instance register and snitun token to new handler

### DIFF
--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -208,6 +208,7 @@ class ApiBase(ABC):
             raise CloudApiClientError(
                 f"Failed to fetch: ({err.status}) {err.message}",
                 orig_exc=err,
+                status=err.status,
             ) from err
         except ClientError as err:
             raise CloudApiClientError(f"Failed to fetch: {err}", orig_exc=err) from err
@@ -280,10 +281,15 @@ class ApiBase(ABC):
         try:
             resp.raise_for_status()
         except ClientResponseError as err:
+            reason = (
+                data.get("reason", data.get("message"))
+                if isinstance(data, dict)
+                else None
+            )
             raise CloudApiError(
                 f"Failed to fetch: ({err.status}) {err.message}",
                 orig_exc=err,
-                reason=data.get("reason") if isinstance(data, dict) else None,
+                reason=reason,
                 status=resp.status,
             ) from err
         return data

--- a/hass_nabucasa/cloud_api.py
+++ b/hass_nabucasa/cloud_api.py
@@ -107,35 +107,18 @@ async def async_create_cloudhook(cloud: Cloud[_ClientT]) -> ClientResponse:
     )
 
 
-@_check_token
-@_log_response
-async def async_remote_register(cloud: Cloud[_ClientT]) -> ClientResponse:
+async def async_remote_register(cloud: Cloud[_ClientT]) -> Any:
     """Create/Get a remote URL."""
-    if TYPE_CHECKING:
-        assert cloud.id_token is not None
-    url = f"https://{cloud.servicehandlers_server}/instance/register"
-    return await cloud.websession.post(
-        url,
-        headers={AUTHORIZATION: cloud.id_token, USER_AGENT: cloud.client.client_name},
-    )
+    return await cloud.instance.register()
 
 
-@_check_token
-@_log_response
 async def async_remote_token(
     cloud: Cloud[_ClientT],
     aes_key: bytes,
     aes_iv: bytes,
-) -> ClientResponse:
+) -> Any:
     """Create a remote snitun token."""
-    if TYPE_CHECKING:
-        assert cloud.id_token is not None
-    url = f"https://{cloud.servicehandlers_server}/instance/snitun_token"
-    return await cloud.websession.post(
-        url,
-        headers={AUTHORIZATION: cloud.id_token, USER_AGENT: cloud.client.client_name},
-        json={"aes_key": aes_key.hex(), "aes_iv": aes_iv.hex()},
-    )
+    return await cloud.instance.snitun_token(aes_key=aes_key, aes_iv=aes_iv)
 
 
 @_check_token

--- a/hass_nabucasa/cloud_api.py
+++ b/hass_nabucasa/cloud_api.py
@@ -107,20 +107,6 @@ async def async_create_cloudhook(cloud: Cloud[_ClientT]) -> ClientResponse:
     )
 
 
-async def async_remote_register(cloud: Cloud[_ClientT]) -> Any:
-    """Create/Get a remote URL."""
-    return await cloud.instance.register()
-
-
-async def async_remote_token(
-    cloud: Cloud[_ClientT],
-    aes_key: bytes,
-    aes_iv: bytes,
-) -> Any:
-    """Create a remote snitun token."""
-    return await cloud.instance.snitun_token(aes_key=aes_key, aes_iv=aes_iv)
-
-
 @_check_token
 async def async_alexa_access_token(cloud: Cloud[_ClientT]) -> ClientResponse:
     """Request Alexa access token."""

--- a/hass_nabucasa/instance_api.py
+++ b/hass_nabucasa/instance_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from aiohttp import hdrs
 
@@ -39,6 +39,15 @@ class InstanceConnectionDisconnected(TypedDict):
 
 
 type InstanceConnection = InstanceConnectionConnnected | InstanceConnectionDisconnected
+
+
+class InstanceRegistrationDetails(TypedDict):
+    """Registration details from instance API."""
+
+    alias: NotRequired[list[str]]
+    domain: str
+    email: str
+    server: str
 
 
 class InstanceApi(ApiBase):
@@ -96,3 +105,22 @@ class InstanceApi(ApiBase):
             path="/instance/dns_challenge_txt",
             jsondata={"txt": value},
         )
+
+    @api_exception_handler(InstanceApiError)
+    async def register(self) -> InstanceRegistrationDetails:
+        """Register the instance."""
+        details: InstanceRegistrationDetails = await self._call_cloud_api(
+            method="POST",
+            path="/instance/register",
+        )
+        return details
+
+    @api_exception_handler(InstanceApiError)
+    async def snitun_token(self, *, aes_key: bytes, aes_iv: bytes) -> dict[str, Any]:
+        """Create a remote snitun token."""
+        details: dict[str, Any] = await self._call_cloud_api(
+            method="POST",
+            path="/instance/snitun_token",
+            jsondata={"aes_key": aes_key.hex(), "aes_iv": aes_iv.hex()},
+        )
+        return details

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -17,7 +17,7 @@ from snitun.exceptions import SniTunConnectionError
 from snitun.utils.aes import generate_aes_keyset
 from snitun.utils.aiohttp_client import SniTunClientAioHttp
 
-from . import cloud_api, const, utils
+from . import const, utils
 from .acme import AcmeClientError, AcmeHandler, AcmeJWSVerificationError
 from .const import (
     DISPATCH_CERTIFICATE_STATUS,
@@ -396,7 +396,9 @@ class RemoteUI:
         aes_key, aes_iv = generate_aes_keyset()
         try:
             async with async_timeout.timeout(30):
-                data = await cloud_api.async_remote_token(self.cloud, aes_key, aes_iv)
+                data = await self.cloud.instance.snitun_token(
+                    aes_key=aes_key, aes_iv=aes_iv
+                )
         except TimeoutError:
             raise RemoteBackendError from None
         except InstanceApiError as err:

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import logging
 import random
 from ssl import SSLContext, SSLError
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 import aiohttp
 import async_timeout
@@ -24,6 +24,7 @@ from .const import (
     CertificateStatus,
     SubscriptionReconnectionReason,
 )
+from .instance_api import InstanceApiError
 
 if TYPE_CHECKING:
     from . import Cloud, _ClientT
@@ -220,20 +221,18 @@ class RemoteUI:
         """Load backend details."""
         try:
             async with async_timeout.timeout(30):
-                resp = await cloud_api.async_remote_register(self.cloud)
-            resp.raise_for_status()
-        except (TimeoutError, aiohttp.ClientError) as err:
+                data = await self.cloud.instance.register()
+        except (TimeoutError, InstanceApiError) as err:
             msg = "Can't update remote details from Home Assistant cloud"
-            if isinstance(err, aiohttp.ClientResponseError):
-                msg += f" ({err.status})"  # pylint: disable=no-member
-            elif isinstance(err, asyncio.TimeoutError):
+            if isinstance(err, TimeoutError):
                 msg += " (timeout)"
+            else:
+                msg += f" ({err})"
             _LOGGER.error(msg)
             return False
-        data = await resp.json()
 
         # Extract data
-        _LOGGER.debug("Retrieve instance data: %s", data)
+        _LOGGER.debug("Retrieved instance data: %s", data)
 
         instance_domain = data["domain"]
         email = data["email"]
@@ -242,7 +241,7 @@ class RemoteUI:
         # Cache data
         self._instance_domain = instance_domain
         self._snitun_server = server
-        self._alias = cast("list[str]", data.get("alias", []))
+        self._alias = data.get("alias", [])
 
         domains: list[str] = [instance_domain, *self._alias]
 
@@ -397,20 +396,15 @@ class RemoteUI:
         aes_key, aes_iv = generate_aes_keyset()
         try:
             async with async_timeout.timeout(30):
-                resp = await cloud_api.async_remote_token(self.cloud, aes_key, aes_iv)
-                if resp.status == 409:
-                    raise RemoteInsecureVersion
-                if resp.status == 403:
-                    msg = ""
-                    if "application/json" in (resp.content_type or ""):
-                        msg = (await resp.json()).get("message", "")
-                    raise RemoteForbidden(msg)
-                if resp.status not in (200, 201):
-                    raise RemoteBackendError
-        except (TimeoutError, aiohttp.ClientError):
+                data = await cloud_api.async_remote_token(self.cloud, aes_key, aes_iv)
+        except TimeoutError:
             raise RemoteBackendError from None
-
-        data = await resp.json()
+        except InstanceApiError as err:
+            if err.status == 409:
+                raise RemoteInsecureVersion from err
+            if err.status == 403:
+                raise RemoteForbidden(err.reason or err) from err
+            raise RemoteBackendError from None
         self._token = SniTunToken(
             data["token"].encode(),
             aes_key,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,14 @@ def auth_cloud_mock(cloud_mock):
     """Return an authenticated cloud instance."""
     cloud_mock.auth.async_check_token.side_effect = AsyncMock()
     cloud_mock.subscription_expired = False
-    cloud_mock.instance = MagicMock(resolve_dns_cname=AsyncMock())
+    cloud_mock.instance = MagicMock(
+        resolve_dns_cname=AsyncMock(),
+        register=AsyncMock(),
+        snitun_token=AsyncMock(),
+        connection=AsyncMock(),
+        create_dns_challenge_record=AsyncMock(),
+        cleanup_dns_challenge_record=AsyncMock(),
+    )
     return cloud_mock
 
 

--- a/tests/test_cloud_api.py
+++ b/tests/test_cloud_api.py
@@ -28,53 +28,6 @@ async def test_create_cloudhook(auth_cloud_mock, aioclient_mock):
     }
 
 
-async def test_remote_register(auth_cloud_mock, aioclient_mock):
-    """Test creating a cloudhook."""
-    aioclient_mock.post(
-        "https://example.com/bla/instance/register",
-        json={
-            "domain": "test.dui.nabu.casa",
-            "email": "test@nabucasa.inc",
-            "server": "rest-remote.nabu.casa",
-        },
-    )
-    auth_cloud_mock.id_token = "mock-id-token"
-    auth_cloud_mock.servicehandlers_server = "example.com/bla"
-
-    resp = await cloud_api.async_remote_register(auth_cloud_mock)
-    assert len(aioclient_mock.mock_calls) == 1
-    assert await resp.json() == {
-        "domain": "test.dui.nabu.casa",
-        "email": "test@nabucasa.inc",
-        "server": "rest-remote.nabu.casa",
-    }
-
-
-async def test_remote_token(auth_cloud_mock, aioclient_mock):
-    """Test creating a cloudhook."""
-    aioclient_mock.post(
-        "https://example.com/instance/snitun_token",
-        json={
-            "token": "123456",
-            "server": "rest-remote.nabu.casa",
-            "valid": 12345,
-            "throttling": 400,
-        },
-    )
-    auth_cloud_mock.id_token = "mock-id-token"
-    auth_cloud_mock.servicehandlers_server = "example.com"
-
-    resp = await cloud_api.async_remote_token(auth_cloud_mock, b"aes", b"iv")
-    assert len(aioclient_mock.mock_calls) == 1
-    assert await resp.json() == {
-        "token": "123456",
-        "server": "rest-remote.nabu.casa",
-        "valid": 12345,
-        "throttling": 400,
-    }
-    assert aioclient_mock.mock_calls[0][2] == {"aes_iv": "6976", "aes_key": "616573"}
-
-
 async def test_get_access_token(auth_cloud_mock, aioclient_mock):
     """Test creating a cloudhook."""
     aioclient_mock.post("https://example.com/alexa/access_token")

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -19,6 +19,7 @@ from hass_nabucasa.const import (
     DISPATCH_REMOTE_DISCONNECT,
     CertificateStatus,
 )
+from hass_nabucasa.instance_api import InstanceApiError
 from hass_nabucasa.remote import (
     RENEW_IF_EXPIRES_DAYS,
     WARN_RENEW_FAILED_DAYS,
@@ -104,6 +105,19 @@ async def test_load_backend_exists_cert(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -193,6 +207,19 @@ async def test_load_backend_not_exists_cert(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -256,6 +283,19 @@ async def test_load_and_unload_backend(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -320,6 +360,20 @@ async def test_load_backend_exists_wrong_cert(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+        "alias": ["example.com"],
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -389,6 +443,19 @@ async def test_call_disconnect(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -432,6 +499,19 @@ async def test_load_backend_no_autostart(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -487,6 +567,19 @@ async def test_get_certificate_details(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     assert remote.certificate is None
@@ -537,6 +630,19 @@ async def test_certificate_task_no_backend(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -587,6 +693,19 @@ async def test_certificate_task_renew_cert(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -646,6 +765,16 @@ async def test_load_connect_insecure(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.side_effect = InstanceApiError(
+        "Remote connection is disabled", status=409
+    )
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -693,6 +822,16 @@ async def test_load_connect_forbidden(
 ):
     """Initialize backend."""
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.side_effect = InstanceApiError(
+        "Remote connection is not allowed", status=403, reason="lorem_ipsum"
+    )
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -736,6 +875,19 @@ async def test_call_disconnect_clean_token(
     """Initialize backend."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -780,6 +932,20 @@ async def test_recreating_old_certificate_with_bad_dns_config(
     """Test recreating old certificate with bad DNS config for alias."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+        "alias": ["example.com"],
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -865,6 +1031,20 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
     """Test warn about old certificate with bad DNS config for alias."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+        "alias": ["example.com"],
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -940,6 +1120,20 @@ async def test_regeneration_without_warning_for_good_dns_config(
     """Test no warning for good dns config."""
     valid = utcnow() + timedelta(days=1)
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+        "alias": ["example.com"],
+    }
+    auth_cloud_mock.instance.snitun_token.return_value = {
+        "token": "test-token",
+        "server": "rest-remote.nabu.casa",
+        "valid": valid.timestamp(),
+        "throttling": 400,
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -1075,6 +1269,12 @@ async def test_acme_client_new_order_errors(
         async def reset_acme(self):
             self.call_reset = True
 
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(
@@ -1125,6 +1325,12 @@ async def test_context_error_handling(
 ):
     """Test that we reset if we hit an error reason that require resetting."""
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+    }
 
     remote = RemoteUI(auth_cloud_mock)
 
@@ -1258,6 +1464,14 @@ async def test_recreate_acme_integration_during_load_backend(
 ):
     """Test _recreate_acme integration during load_backend with domain changes."""
     auth_cloud_mock.servicehandlers_server = "test.local"
+
+    auth_cloud_mock.instance.register.return_value = {
+        "domain": "test.dui.nabu.casa",
+        "email": "test@nabucasa.inc",
+        "server": "rest-remote.nabu.casa",
+        "alias": ["new-alias.com"],
+    }
+
     remote = RemoteUI(auth_cloud_mock)
 
     aioclient_mock.post(


### PR DESCRIPTION
This pull request refactors the handling of remote instance registration and token generation in the `hass_nabucasa` package. The changes streamline the code by delegating these operations to the `InstanceApi` class, improving maintainability and simplifying API calls. Additionally, the test suite has been updated to reflect these changes.

### Refactoring and API Improvements:

* **Centralized Instance API Handling**: Introduced new methods `register` and `snitun_token` in the `InstanceApi` class to encapsulate instance registration and token generation logic. This eliminates repetitive code and improves readability. (`hass_nabucasa/instance_api.py`)
* **Error Handling Enhancements**: Updated exception handling in `_call_cloud_api` to provide more meaningful error messages and reasons when API calls fail. (`hass_nabucasa/api.py`) [[1]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R211) [[2]](diffhunk://#diff-0c57b34910e1f0dc8a7f616106b9dad41830a712e954395d3af52747918c3354R284-R292)
* **Removed Legacy Code**: Deprecated the `async_remote_register` and `async_remote_token` methods in favor of the new `InstanceApi` methods. (`hass_nabucasa/cloud_api.py`)

### Updates to Remote Functionality:

* **Refactored Remote Backend Logic**: Modified `load_backend` and `_refresh_snitun_token` methods in `RemoteUI` to use the new `InstanceApi` methods, simplifying the flow and improving error handling. (`hass_nabucasa/remote.py`) [[1]](diffhunk://#diff-a117242017e3842c5e8ba7b49da95a5465303e5f01699a8ffd6f5e06c25b6c52L223-R235) [[2]](diffhunk://#diff-a117242017e3842c5e8ba7b49da95a5465303e5f01699a8ffd6f5e06c25b6c52L400-L413)
* **Type Hint Adjustments**: Updated type hints for improved clarity, including the use of `NotRequired` in `InstanceRegistrationDetails`. (`hass_nabucasa/instance_api.py`) [[1]](diffhunk://#diff-140f80c9e8710c585a4925f8d0e6328e37be3a0be07616b818219526528f48a1L6-R6) [[2]](diffhunk://#diff-140f80c9e8710c585a4925f8d0e6328e37be3a0be07616b818219526528f48a1R44-R52)
