### PR TITLE
Move /instance/resolve_dns_cname to a dedicated accounts api class

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -17,6 +17,7 @@ from atomicwrites import atomic_write
 import jwt
 
 from .account_api import AccountApi, AccountApiError
+from .accounts_api import AccountsApi, AccountsApiError
 from .alexa_api import AlexaApi, AlexaApiError
 from .api import (
     CloudApiClientError,
@@ -63,6 +64,8 @@ from .voice_api import VoiceApi, VoiceApiError
 __all__ = [
     "MODE_DEV",
     "AccountApiError",
+    "AccountsApi",
+    "AccountsApiError",
     "AlexaApiError",
     "AlreadyConnectedError",
     "CertificateStatus",
@@ -169,6 +172,7 @@ class Cloud(Generic[_ClientT]):
 
         # Setup the rest of the components
         self.account = AccountApi(self)
+        self.accounts = AccountsApi(self)
         self.alexa_api = AlexaApi(self)
         self.auth = CognitoAuth(self)
         self.cloudhooks = Cloudhooks(self)

--- a/hass_nabucasa/accounts_api.py
+++ b/hass_nabucasa/accounts_api.py
@@ -1,0 +1,32 @@
+"""Manage accounts API."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .api import ApiBase, CloudApiError, api_exception_handler
+
+
+class AccountsApiError(CloudApiError):
+    """Exception raised when handling account API."""
+
+
+class AccountsApi(ApiBase):
+    """Class to help communicate with the accounts API."""
+
+    @property
+    def hostname(self) -> str:
+        """Get the hostname."""
+        if TYPE_CHECKING:
+            assert self._cloud.accounts_server is not None
+        return self._cloud.accounts_server
+
+    @api_exception_handler(AccountsApiError)
+    async def instance_resolve_dns_cname(self, *, hostname: str) -> list[str]:
+        """Resolve DNS CNAME."""
+        details: list[str] = await self._call_cloud_api(
+            method="POST",
+            path="/instance/resolve_dns_cname",
+            jsondata={"hostname": hostname},
+        )
+        return details

--- a/hass_nabucasa/instance_api.py
+++ b/hass_nabucasa/instance_api.py
@@ -88,16 +88,6 @@ class InstanceApi(ApiBase):
         return details
 
     @api_exception_handler(InstanceApiError)
-    async def resolve_dns_cname(self, *, hostname: str) -> list[str]:
-        """Resolve DNS CNAME."""
-        details: list[str] = await self._call_cloud_api(
-            method="POST",
-            path="/instance/resolve_dns_cname",
-            jsondata={"hostname": hostname},
-        )
-        return details
-
-    @api_exception_handler(InstanceApiError)
     async def cleanup_dns_challenge_record(self, *, value: str) -> None:
         """Remove DNS challenge."""
         await self._call_cloud_api(

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -581,7 +581,9 @@ class RemoteUI:
     async def _check_cname(self, hostname: str) -> list[str]:
         """Get CNAME records for hostname."""
         try:
-            return await self.cloud.instance.resolve_dns_cname(hostname=hostname)
+            return await self.cloud.accounts.instance_resolve_dns_cname(
+                hostname=hostname
+            )
         except (TimeoutError, aiohttp.ClientError):
             _LOGGER.error("Can't resolve CNAME for %s", hostname)
         return []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,8 +110,7 @@ def mock_iot_client(cloud_mock):
 
         def auto_close(self, msg_count=1):
             """If the client should disconnect itself after 1 message."""
-            Client.closed = PropertyMock(
-                side_effect=msg_count * [False] + [True])
+            Client.closed = PropertyMock(side_effect=msg_count * [False] + [True])
 
         async def close(self):
             """Close the client."""
@@ -159,8 +158,7 @@ async def ws_server(aiohttp_client):
                         logger.debug("Sending msg: %s", msg)
                         await ws.send_json(resp)
                 except DisconnectMockServer:
-                    logger.debug(
-                        "Closing connection (via DisconnectMockServer)")
+                    logger.debug("Closing connection (via DisconnectMockServer)")
                     await ws.close()
 
             return ws

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,9 @@ async def cloud_mock(loop, aioclient_mock, tmp_path):
 @pytest.fixture
 def auth_cloud_mock(cloud_mock):
     """Return an authenticated cloud instance."""
+    cloud_mock.accounts = MagicMock(
+        instance_resolve_dns_cname=AsyncMock(),
+    )
     cloud_mock.auth.async_check_token.side_effect = AsyncMock()
     cloud_mock.subscription_expired = False
     cloud_mock.instance = MagicMock(
@@ -107,7 +110,8 @@ def mock_iot_client(cloud_mock):
 
         def auto_close(self, msg_count=1):
             """If the client should disconnect itself after 1 message."""
-            Client.closed = PropertyMock(side_effect=msg_count * [False] + [True])
+            Client.closed = PropertyMock(
+                side_effect=msg_count * [False] + [True])
 
         async def close(self):
             """Close the client."""
@@ -155,7 +159,8 @@ async def ws_server(aiohttp_client):
                         logger.debug("Sending msg: %s", msg)
                         await ws.send_json(resp)
                 except DisconnectMockServer:
-                    logger.debug("Closing connection (via DisconnectMockServer)")
+                    logger.debug(
+                        "Closing connection (via DisconnectMockServer)")
                     await ws.close()
 
             return ws

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -1,0 +1,102 @@
+"""Tests for Instance API."""
+
+import re
+from typing import Any
+
+from aiohttp import ClientError
+import pytest
+
+from hass_nabucasa import AccountsApi, AccountsApiError, Cloud
+from tests.utils.aiohttp import AiohttpClientMocker
+
+API_HOSTNAME = "example.com"
+
+
+@pytest.fixture(autouse=True)
+def set_hostname(auth_cloud_mock: Cloud):
+    """Set API hostname for the mock cloud service."""
+    auth_cloud_mock.accounts_server = API_HOSTNAME
+
+
+@pytest.mark.parametrize(
+    "exception,mockargs,log_msg_template,exception_msg",
+    [
+        [
+            AccountsApiError,
+            {"status": 500, "text": "Internal Server Error"},
+            "Response for post from example.com/instance/resolve_dns_cname (500)",
+            "Failed to fetch: (500) ",
+        ],
+        [
+            AccountsApiError,
+            {"status": 429, "text": "Too fast"},
+            "Response for post from example.com/instance/resolve_dns_cname (429)",
+            "Failed to fetch: (429) ",
+        ],
+        [
+            AccountsApiError,
+            {"exc": TimeoutError()},
+            "",
+            "Timeout reached while calling API",
+        ],
+        [
+            AccountsApiError,
+            {"exc": ClientError("boom!")},
+            "",
+            "Failed to fetch: boom!",
+        ],
+        [
+            AccountsApiError,
+            {"exc": Exception("boom!")},
+            "",
+            "Unexpected error while calling API: boom!",
+        ],
+    ],
+    ids=["500-error", "429-error", "timeout",
+         "client-error", "unexpected-error"],
+)
+async def test_resolve_dns_cname_endpoint_problems(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    exception: Exception,
+    mockargs: dict[str, Any],
+    log_msg_template: str,
+    exception_msg: str,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test problems with resolve_dns_cname endpoint."""
+    accouunts_api = AccountsApi(auth_cloud_mock)
+
+    aioclient_mock.post(
+        f"https://{API_HOSTNAME}/instance/resolve_dns_cname",
+        **mockargs,
+    )
+
+    with pytest.raises(exception, match=re.escape(exception_msg)):
+        await accouunts_api.instance_resolve_dns_cname(hostname="example.com")
+
+    if log_msg_template:
+        assert log_msg_template in caplog.text
+
+
+async def test_resolve_dns_cname_endpoint_success(
+    aioclient_mock: AiohttpClientMocker,
+    auth_cloud_mock: Cloud,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test successful resolve_dns_cname endpoint."""
+    accounts_api = AccountsApi(auth_cloud_mock)
+    expected_result = ["alias1.example.com", "alias2.example.com"]
+
+    aioclient_mock.post(
+        f"https://{API_HOSTNAME}/instance/resolve_dns_cname",
+        json=expected_result,
+    )
+
+    result = await accounts_api.instance_resolve_dns_cname(hostname="example.com")
+
+    assert result == expected_result
+    assert (
+        "Response for post from example.com/instance/resolve_dns_cname (200)"
+        in caplog.text
+    )

--- a/tests/test_accounts_api.py
+++ b/tests/test_accounts_api.py
@@ -52,8 +52,7 @@ def set_hostname(auth_cloud_mock: Cloud):
             "Unexpected error while calling API: boom!",
         ],
     ],
-    ids=["500-error", "429-error", "timeout",
-         "client-error", "unexpected-error"],
+    ids=["500-error", "429-error", "timeout", "client-error", "unexpected-error"],
 )
 async def test_resolve_dns_cname_endpoint_problems(
     aioclient_mock: AiohttpClientMocker,

--- a/tests/test_instance_api.py
+++ b/tests/test_instance_api.py
@@ -88,66 +88,6 @@ async def test_connection_endpoint_problems(
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Response for post from example.com/instance/resolve_dns_cname (500)",
-            "Failed to fetch: (500) ",
-        ],
-        [
-            InstanceApiError,
-            {"status": 429, "text": "Too fast"},
-            "Response for post from example.com/instance/resolve_dns_cname (429)",
-            "Failed to fetch: (429) ",
-        ],
-        [
-            InstanceApiError,
-            {"exc": TimeoutError()},
-            "",
-            "Timeout reached while calling API",
-        ],
-        [
-            InstanceApiError,
-            {"exc": ClientError("boom!")},
-            "",
-            "Failed to fetch: boom!",
-        ],
-        [
-            InstanceApiError,
-            {"exc": Exception("boom!")},
-            "",
-            "Unexpected error while calling API: boom!",
-        ],
-    ],
-    ids=["500-error", "429-error", "timeout", "client-error", "unexpected-error"],
-)
-async def test_resolve_dns_cname_endpoint_problems(
-    aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
-    exception: Exception,
-    mockargs: dict[str, Any],
-    log_msg_template: str,
-    exception_msg: str,
-    caplog: pytest.LogCaptureFixture,
-):
-    """Test problems with resolve_dns_cname endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
-    aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/resolve_dns_cname",
-        **mockargs,
-    )
-
-    with pytest.raises(exception, match=re.escape(exception_msg)):
-        await instance_api.resolve_dns_cname(hostname="example.com")
-
-    if log_msg_template:
-        assert log_msg_template in caplog.text
-
-
-@pytest.mark.parametrize(
-    "exception,mockargs,log_msg_template,exception_msg",
-    [
-        [
-            InstanceApiError,
-            {"status": 500, "text": "Internal Server Error"},
             "Response for post from example.com/instance/dns_challenge_cleanup (500)",
             "Failed to fetch: (500) ",
         ],
@@ -280,29 +220,6 @@ async def test_connection_endpoint_success(
 
     assert result == expected_result
     assert "Response for get from example.com/instance/connection (200)" in caplog.text
-
-
-async def test_resolve_dns_cname_endpoint_success(
-    aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
-    caplog: pytest.LogCaptureFixture,
-):
-    """Test successful resolve_dns_cname endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-    expected_result = ["alias1.example.com", "alias2.example.com"]
-
-    aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/resolve_dns_cname",
-        json=expected_result,
-    )
-
-    result = await instance_api.resolve_dns_cname(hostname="example.com")
-
-    assert result == expected_result
-    assert (
-        "Response for post from example.com/instance/resolve_dns_cname (200)"
-        in caplog.text
-    )
 
 
 async def test_cleanup_dns_challenge_record_endpoint_success(

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -155,8 +155,7 @@ async def test_load_backend_exists_cert(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -189,10 +188,8 @@ async def test_load_backend_exists_cert(
         for call in auth_cloud_mock.client.mock_dispatcher
         if call[0] in (DISPATCH_REMOTE_BACKEND_UP, DISPATCH_REMOTE_CONNECT)
     ]
-    assert any(
-        call[0] == DISPATCH_REMOTE_BACKEND_UP for call in backend_dispatches)
-    assert any(
-        call[0] == DISPATCH_REMOTE_CONNECT for call in backend_dispatches)
+    assert any(call[0] == DISPATCH_REMOTE_BACKEND_UP for call in backend_dispatches)
+    assert any(call[0] == DISPATCH_REMOTE_CONNECT for call in backend_dispatches)
 
     await remote.stop()
     await asyncio.sleep(0.1)
@@ -257,8 +254,7 @@ async def test_load_backend_not_exists_cert(
     )
     assert acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -334,8 +330,7 @@ async def test_load_and_unload_backend(
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
     assert not snitun_mock.call_stop
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -422,8 +417,7 @@ async def test_load_backend_exists_wrong_cert(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -997,8 +991,7 @@ async def test_recreating_old_certificate_with_bad_dns_config(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1013,8 +1006,7 @@ async def test_recreating_old_certificate_with_bad_dns_config(
         "placeholders",
     }
 
-    assert repair["identifier"].startswith(
-        "reset_bad_custom_domain_configuration_")
+    assert repair["identifier"].startswith("reset_bad_custom_domain_configuration_")
     assert repair["translation_key"] == "reset_bad_custom_domain_configuration"
     assert repair["severity"] == "error"
     assert repair["placeholders"] == {"custom_domains": "example.com"}
@@ -1089,8 +1081,7 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
     assert remote.snitun_server == "rest-remote.nabu.casa"
     assert not valid_acme_mock.call_reset
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1104,8 +1095,7 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
         "severity",
         "placeholders",
     }
-    assert repair["identifier"].startswith(
-        "warn_bad_custom_domain_configuration_")
+    assert repair["identifier"].startswith("warn_bad_custom_domain_configuration_")
     assert repair["translation_key"] == "warn_bad_custom_domain_configuration"
     assert repair["severity"] == "warning"
     assert repair["placeholders"] == {"custom_domains": "example.com"}
@@ -1182,8 +1172,7 @@ async def test_regeneration_without_warning_for_good_dns_config(
     assert not valid_acme_mock.call_reset
     assert valid_acme_mock.call_issue
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (
-        auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1300,8 +1289,7 @@ async def test_acme_client_new_order_errors(
 
     with patch(
         "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [],
-                               "test@nabucasa.inc", Mock()),
+        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc", Mock()),
     ):
         assert remote._certificate_status is None
         await remote.load_backend()
@@ -1414,8 +1402,7 @@ async def test_acme_client_create_client_jws_errors(
 
     with patch(
         "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [],
-                               "test@nabucasa.inc", Mock()),
+        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc", Mock()),
     ):
         assert remote._certificate_status is None
         await remote.load_backend()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -155,7 +155,8 @@ async def test_load_backend_exists_cert(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -188,8 +189,10 @@ async def test_load_backend_exists_cert(
         for call in auth_cloud_mock.client.mock_dispatcher
         if call[0] in (DISPATCH_REMOTE_BACKEND_UP, DISPATCH_REMOTE_CONNECT)
     ]
-    assert any(call[0] == DISPATCH_REMOTE_BACKEND_UP for call in backend_dispatches)
-    assert any(call[0] == DISPATCH_REMOTE_CONNECT for call in backend_dispatches)
+    assert any(
+        call[0] == DISPATCH_REMOTE_BACKEND_UP for call in backend_dispatches)
+    assert any(
+        call[0] == DISPATCH_REMOTE_CONNECT for call in backend_dispatches)
 
     await remote.stop()
     await asyncio.sleep(0.1)
@@ -254,7 +257,8 @@ async def test_load_backend_not_exists_cert(
     )
     assert acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -330,7 +334,8 @@ async def test_load_and_unload_backend(
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
     assert not snitun_mock.call_stop
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -396,7 +401,7 @@ async def test_load_backend_exists_wrong_cert(
         },
     )
 
-    auth_cloud_mock.instance.resolve_dns_cname.return_value = [
+    auth_cloud_mock.accounts.instance_resolve_dns_cname.return_value = [
         "test.dui.nabu.casa",
         "_acme-challenge.test.dui.nabu.casa",
     ]
@@ -417,7 +422,8 @@ async def test_load_backend_exists_wrong_cert(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -991,7 +997,8 @@ async def test_recreating_old_certificate_with_bad_dns_config(
     )
     assert valid_acme_mock.call_hardening
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1006,7 +1013,8 @@ async def test_recreating_old_certificate_with_bad_dns_config(
         "placeholders",
     }
 
-    assert repair["identifier"].startswith("reset_bad_custom_domain_configuration_")
+    assert repair["identifier"].startswith(
+        "reset_bad_custom_domain_configuration_")
     assert repair["translation_key"] == "reset_bad_custom_domain_configuration"
     assert repair["severity"] == "error"
     assert repair["placeholders"] == {"custom_domains": "example.com"}
@@ -1066,7 +1074,7 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
             "throttling": 400,
         },
     )
-    auth_cloud_mock.instance.resolve_dns_cname.side_effect = ClientError(
+    auth_cloud_mock.accounts.instance_resolve_dns_cname.side_effect = ClientError(
         "DNS resolution failed"
     )
 
@@ -1081,7 +1089,8 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
     assert remote.snitun_server == "rest-remote.nabu.casa"
     assert not valid_acme_mock.call_reset
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1095,7 +1104,8 @@ async def test_warn_about_bad_dns_config_for_old_certificate(
         "severity",
         "placeholders",
     }
-    assert repair["identifier"].startswith("warn_bad_custom_domain_configuration_")
+    assert repair["identifier"].startswith(
+        "warn_bad_custom_domain_configuration_")
     assert repair["translation_key"] == "warn_bad_custom_domain_configuration"
     assert repair["severity"] == "warning"
     assert repair["placeholders"] == {"custom_domains": "example.com"}
@@ -1155,7 +1165,7 @@ async def test_regeneration_without_warning_for_good_dns_config(
             "throttling": 400,
         },
     )
-    auth_cloud_mock.instance.resolve_dns_cname.return_value = [
+    auth_cloud_mock.accounts.instance_resolve_dns_cname.return_value = [
         "test.dui.nabu.casa",
         "_acme-challenge.test.dui.nabu.casa",
     ]
@@ -1172,7 +1182,8 @@ async def test_regeneration_without_warning_for_good_dns_config(
     assert not valid_acme_mock.call_reset
     assert valid_acme_mock.call_issue
     assert snitun_mock.call_start
-    assert snitun_mock.init_args == (auth_cloud_mock.client.aiohttp_runner, None)
+    assert snitun_mock.init_args == (
+        auth_cloud_mock.client.aiohttp_runner, None)
     assert snitun_mock.init_kwarg == {
         "snitun_server": "rest-remote.nabu.casa",
         "snitun_port": 443,
@@ -1289,7 +1300,8 @@ async def test_acme_client_new_order_errors(
 
     with patch(
         "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc", Mock()),
+        return_value=_MockAcme(auth_cloud_mock, [],
+                               "test@nabucasa.inc", Mock()),
     ):
         assert remote._certificate_status is None
         await remote.load_backend()
@@ -1402,7 +1414,8 @@ async def test_acme_client_create_client_jws_errors(
 
     with patch(
         "hass_nabucasa.remote.AcmeHandler",
-        return_value=_MockAcme(auth_cloud_mock, [], "test@nabucasa.inc", Mock()),
+        return_value=_MockAcme(auth_cloud_mock, [],
+                               "test@nabucasa.inc", Mock()),
     ):
         assert remote._certificate_status is None
         await remote.load_backend()
@@ -1601,7 +1614,7 @@ async def test_recreate_acme_integration_during_load_backend(
     valid_acme_mock.common_name = "test.dui.nabu.casa"
     valid_acme_mock.alternative_names = ["test.dui.nabu.casa", "old-alias.com"]
 
-    auth_cloud_mock.instance.resolve_dns_cname.return_value = [
+    auth_cloud_mock.accounts.instance_resolve_dns_cname.return_value = [
         "test.dui.nabu.casa",
         "_acme-challenge.test.dui.nabu.casa",
     ]


### PR DESCRIPTION
This was moved to https://github.com/NabuCasa/hass-nabucasa/pull/898, but to the wrong place. It belongs under the accounts API and not under servicehandlers.