### PR TITLE
Add pytest-socket to block sockets in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ test = [
     "pre-commit-hooks==5.0.0",
     "pylint==3.3.7",
     "pytest-aiohttp==1.1.0",
+    "pytest-socket==0.7.0",
     "pytest-timeout==2.4.0",
     "pytest==8.4.1",
     "ruff==0.12.7",
@@ -132,6 +133,7 @@ reports=false
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 timeout = 5
+addopts = "--disable-socket --allow-hosts=127.0.0.1"
 
 [tool.ruff]
 fix = true


### PR DESCRIPTION
This pull request updates the testing configuration to improve test isolation and security. The main changes are the addition of the `pytest-socket` dependency and configuration to restrict network access during tests.

**Testing dependencies and configuration:**

* Added `pytest-socket==0.7.0` to the `test` dependencies in `pyproject.toml`, enabling control over socket usage in tests.
* Updated the pytest configuration in `pyproject.toml` to include `addopts = "--disable-socket --allow-hosts=127.0.0.1"`, which disables external network calls during tests except to localhost.