### PR TITLE
Refactor tests for Instance API endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,7 @@ repos:
         name: Trim Trailing Whitespace
         language: system
         types: [text]
+        exclude: __snapshots__
         entry: trailing-whitespace-fixer
         stages: [pre-commit, pre-push, manual]
       - id: mypy

--- a/tests/__snapshots__/test_instance_api.ambr
+++ b/tests/__snapshots__/test_instance_api.ambr
@@ -1,0 +1,94 @@
+# serializer version: 1
+# name: test_cleanup_dns_challenge_record_endpoint_problems[429-error]
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_cleanup (429) 
+  '''
+# ---
+# name: test_cleanup_dns_challenge_record_endpoint_problems[500-error]
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_cleanup (500) 
+  '''
+# ---
+# name: test_cleanup_dns_challenge_record_endpoint_problems[client-error]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup'
+# ---
+# name: test_cleanup_dns_challenge_record_endpoint_problems[timeout]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup'
+# ---
+# name: test_cleanup_dns_challenge_record_endpoint_problems[unexpected-error]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup'
+# ---
+# name: test_cleanup_dns_challenge_record_endpoint_success
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_cleanup
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_cleanup (200) 
+  '''
+# ---
+# name: test_connection_endpoint_problems[429-error]
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  [DEBUG] hass_nabucasa.api: Response for get from servicehandlers.example.com/instance/connection (429) 
+  '''
+# ---
+# name: test_connection_endpoint_problems[500-error]
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  [DEBUG] hass_nabucasa.api: Response for get from servicehandlers.example.com/instance/connection (500) 
+  '''
+# ---
+# name: test_connection_endpoint_problems[client-error]
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  '''
+# ---
+# name: test_connection_endpoint_problems[timeout]
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  '''
+# ---
+# name: test_connection_endpoint_problems[unexpected-error]
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  '''
+# ---
+# name: test_connection_endpoint_success
+  '''
+  [DEBUG] hass_nabucasa.instance_api: Getting instance connection details
+  [DEBUG] hass_nabucasa.api: Sending GET request to servicehandlers.example.com/instance/connection
+  [DEBUG] hass_nabucasa.api: Response for get from servicehandlers.example.com/instance/connection (200) 
+  '''
+# ---
+# name: test_create_dns_challenge_record_endpoint_problems[429-error]
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_txt (429) 
+  '''
+# ---
+# name: test_create_dns_challenge_record_endpoint_problems[500-error]
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_txt (500) 
+  '''
+# ---
+# name: test_create_dns_challenge_record_endpoint_problems[client-error]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt'
+# ---
+# name: test_create_dns_challenge_record_endpoint_problems[timeout]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt'
+# ---
+# name: test_create_dns_challenge_record_endpoint_problems[unexpected-error]
+  '[DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt'
+# ---
+# name: test_create_dns_challenge_record_endpoint_success
+  '''
+  [DEBUG] hass_nabucasa.api: Sending POST request to servicehandlers.example.com/instance/dns_challenge_txt
+  [DEBUG] hass_nabucasa.api: Response for post from servicehandlers.example.com/instance/dns_challenge_txt (200) 
+  '''
+# ---

--- a/tests/common.py
+++ b/tests/common.py
@@ -9,6 +9,8 @@ import threading
 from typing import Any, Literal
 from unittest.mock import Mock
 
+import pytest
+
 from hass_nabucasa.client import CloudClient
 
 FROZEN_NOW_AS_TIMESTAMP = 1537185600  # 2018-09-17 12:00:00 UTC
@@ -286,3 +288,13 @@ class MockSnitun:
         self.init_args = args
         self.init_kwarg = kwarg
         return self
+
+
+def extract_log_messages(caplog: pytest.LogCaptureFixture) -> str:
+    """Extract log messages as string from caplog fixture."""
+    return "\n".join(
+        [
+            f"[{record.levelname}] {record.name}: {record.message}"
+            for record in caplog.records
+        ]
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,21 @@
 """Set up some common test helper things."""
 
 import asyncio
+from collections.abc import AsyncGenerator
 import logging
-from typing import cast
+from pathlib import Path
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiohttp import web
 from freezegun import freeze_time
+import jwt
 import pytest
 
+import hass_nabucasa
+
 from .common import MockClient
-from .utils.aiohttp import mock_aiohttp_client
+from .utils.aiohttp import AiohttpClientMocker, mock_aiohttp_client
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -90,6 +95,90 @@ def auth_cloud_mock(cloud_mock):
 def cloud_client(cloud_mock: MagicMock) -> MockClient:
     """Return cloud client impl."""
     return cast("MockClient", cloud_mock.client)
+
+
+@pytest.fixture
+async def cloud(
+    aioclient_mock: AiohttpClientMocker,
+    loop: asyncio.AbstractEventLoop,
+    tmp_path: Path,
+) -> AsyncGenerator[hass_nabucasa.Cloud, Any]:
+    """Create a cloud fixture."""
+    client_session = aioclient_mock.create_session(loop)
+    client = MockClient(tmp_path, loop, client_session)
+
+    cloud_dir = tmp_path / ".cloud"
+    cloud_dir.mkdir(exist_ok=True)
+
+    with (
+        patch("pathlib.Path.chmod"),
+        patch("pathlib.Path.read_text", return_value=""),
+        patch("pathlib.Path.write_bytes"),
+        patch("pathlib.Path.write_text"),
+        patch("shutil.rmtree"),
+    ):
+        cloud = hass_nabucasa.Cloud(
+            client,
+            "development",
+            cognito_client_id="abc123",
+            region="xx-earth-616",
+            account_link_server="accout-link.example.com",
+            accounts_server="accounts.example.com",
+            cloudhook_server="cloudhooks.example.com",
+            acme_server="acme.example.com",
+            relayer_server="relayer.example.com",
+            remotestate_server="remotestate.example.com",
+            servicehandlers_server="servicehandlers.example.com",
+        )
+
+        fake_secret = "fake-test-secret"
+
+        id_token_claims = {
+            "cognito:username": "test@example.com",
+            "custom:sub-exp": "2019-09-17",
+            "iat": 1537185600,
+            "exp": 1537185600 + (365 * 24 * 60 * 60),
+            "token_use": "id",
+        }
+
+        access_token_claims = {
+            "client_id": "test-client-id",
+            "username": "test@example.com",
+            "token_use": "access",
+            "scope": "aws.cognito.signin.user.admin",
+            "iat": 1537185600,
+            "exp": 1537185600 + 3600,
+        }
+
+        refresh_token_claims = {
+            "client_id": "test-client-id",
+            "username": "test@example.com",
+            "token_use": "refresh",
+            "iat": 1537185600,
+            "exp": 1537185600 + (30 * 24 * 60 * 60),
+        }
+
+        id_token = jwt.encode(id_token_claims, fake_secret, algorithm="HS256")
+        access_token = jwt.encode(access_token_claims, fake_secret, algorithm="HS256")
+        refresh_token = jwt.encode(refresh_token_claims, fake_secret, algorithm="HS256")
+        renewed_id_token = jwt.encode(id_token_claims, fake_secret, algorithm="HS256")
+        renewed_access_token = jwt.encode(
+            access_token_claims, fake_secret, algorithm="HS256"
+        )
+
+        mock_cognito = MagicMock()
+        mock_cognito.id_token = renewed_id_token
+        mock_cognito.access_token = renewed_access_token
+        cloud.auth._create_cognito_client = MagicMock(return_value=mock_cognito)
+
+        cloud.auth.async_check_token = AsyncMock()
+
+        cloud.id_token = id_token
+        cloud.access_token = access_token
+        cloud.refresh_token = refresh_token
+
+        yield cloud
+        await client_session.close()
 
 
 @pytest.fixture

--- a/tests/test_instance_api.py
+++ b/tests/test_instance_api.py
@@ -5,54 +5,44 @@ from typing import Any
 
 from aiohttp import ClientError
 import pytest
+from syrupy import SnapshotAssertion
 
 from hass_nabucasa import Cloud
 from hass_nabucasa.instance_api import (
-    InstanceApi,
     InstanceApiError,
 )
+from tests.common import extract_log_messages
 from tests.utils.aiohttp import AiohttpClientMocker
 
 API_HOSTNAME = "example.com"
 
 
-@pytest.fixture(autouse=True)
-def set_hostname(auth_cloud_mock: Cloud):
-    """Set API hostname for the mock cloud service."""
-    auth_cloud_mock.servicehandlers_server = API_HOSTNAME
-
-
 @pytest.mark.parametrize(
-    "exception,mockargs,log_msg_template,exception_msg",
+    "exception,mockargs,exception_msg",
     [
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Response for get from example.com/instance/connection (500)",
             "Failed to parse API response",
         ],
         [
             InstanceApiError,
             {"status": 429, "text": "Too fast"},
-            "Response for get from example.com/instance/connection (429)",
             "Failed to parse API response",
         ],
         [
             InstanceApiError,
             {"exc": TimeoutError()},
-            "",
             "Timeout reached while calling API",
         ],
         [
             InstanceApiError,
             {"exc": ClientError("boom!")},
-            "",
             "Failed to fetch: boom!",
         ],
         [
             InstanceApiError,
             {"exc": Exception("boom!")},
-            "",
             "Unexpected error while calling API: boom!",
         ],
     ],
@@ -60,59 +50,51 @@ def set_hostname(auth_cloud_mock: Cloud):
 )
 async def test_connection_endpoint_problems(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     exception: Exception,
     mockargs: dict[str, Any],
-    log_msg_template: str,
+    snapshot: SnapshotAssertion,
     exception_msg: str,
     caplog: pytest.LogCaptureFixture,
 ):
     """Test problems with connection endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
     aioclient_mock.get(
-        f"https://{API_HOSTNAME}/instance/connection",
+        f"https://{cloud.servicehandlers_server}/instance/connection",
         **mockargs,
     )
 
     with pytest.raises(exception, match=re.escape(exception_msg)):
-        await instance_api.connection()
+        await cloud.instance.connection()
 
-    if log_msg_template:
-        assert log_msg_template in caplog.text
+    assert snapshot == extract_log_messages(caplog)
 
 
 @pytest.mark.parametrize(
-    "exception,mockargs,log_msg_template,exception_msg",
+    "exception,mockargs,exception_msg",
     [
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Response for post from example.com/instance/dns_challenge_cleanup (500)",
             "Failed to fetch: (500) ",
         ],
         [
             InstanceApiError,
             {"status": 429, "text": "Too fast"},
-            "Response for post from example.com/instance/dns_challenge_cleanup (429)",
             "Failed to fetch: (429) ",
         ],
         [
             InstanceApiError,
             {"exc": TimeoutError()},
-            "",
             "Timeout reached while calling API",
         ],
         [
             InstanceApiError,
             {"exc": ClientError("boom!")},
-            "",
             "Failed to fetch: boom!",
         ],
         [
             InstanceApiError,
             {"exc": Exception("boom!")},
-            "",
             "Unexpected error while calling API: boom!",
         ],
     ],
@@ -120,59 +102,51 @@ async def test_connection_endpoint_problems(
 )
 async def test_cleanup_dns_challenge_record_endpoint_problems(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     exception: Exception,
     mockargs: dict[str, Any],
-    log_msg_template: str,
+    snapshot: SnapshotAssertion,
     exception_msg: str,
     caplog: pytest.LogCaptureFixture,
 ):
     """Test problems with cleanup_dns_challenge_record endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
     aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/dns_challenge_cleanup",
+        f"https://{cloud.servicehandlers_server}/instance/dns_challenge_cleanup",
         **mockargs,
     )
 
     with pytest.raises(exception, match=re.escape(exception_msg)):
-        await instance_api.cleanup_dns_challenge_record(value="challenge-value")
+        await cloud.instance.cleanup_dns_challenge_record(value="challenge-value")
 
-    if log_msg_template:
-        assert log_msg_template in caplog.text
+    assert snapshot == extract_log_messages(caplog)
 
 
 @pytest.mark.parametrize(
-    "exception,mockargs,log_msg_template,exception_msg",
+    "exception,mockargs,exception_msg",
     [
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Response for post from example.com/instance/dns_challenge_txt (500)",
             "Failed to fetch: (500) ",
         ],
         [
             InstanceApiError,
             {"status": 429, "text": "Too fast"},
-            "Response for post from example.com/instance/dns_challenge_txt (429)",
             "Failed to fetch: (429) ",
         ],
         [
             InstanceApiError,
             {"exc": TimeoutError()},
-            "",
             "Timeout reached while calling API",
         ],
         [
             InstanceApiError,
             {"exc": ClientError("boom!")},
-            "",
             "Failed to fetch: boom!",
         ],
         [
             InstanceApiError,
             {"exc": Exception("boom!")},
-            "",
             "Unexpected error while calling API: boom!",
         ],
     ],
@@ -180,87 +154,76 @@ async def test_cleanup_dns_challenge_record_endpoint_problems(
 )
 async def test_create_dns_challenge_record_endpoint_problems(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     exception: Exception,
     mockargs: dict[str, Any],
-    log_msg_template: str,
+    snapshot: SnapshotAssertion,
     exception_msg: str,
     caplog: pytest.LogCaptureFixture,
 ):
     """Test problems with create_dns_challenge_record endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
     aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/dns_challenge_txt",
+        f"https://{cloud.servicehandlers_server}/instance/dns_challenge_txt",
         **mockargs,
     )
 
     with pytest.raises(exception, match=re.escape(exception_msg)):
-        await instance_api.create_dns_challenge_record(value="challenge-value")
+        await cloud.instance.create_dns_challenge_record(value="challenge-value")
 
-    if log_msg_template:
-        assert log_msg_template in caplog.text
+    assert snapshot == extract_log_messages(caplog)
 
 
 async def test_connection_endpoint_success(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
 ):
     """Test successful connection endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
     expected_result = {"connected": True, "details": {}}
 
     aioclient_mock.get(
-        f"https://{API_HOSTNAME}/instance/connection",
+        f"https://{cloud.servicehandlers_server}/instance/connection",
         json=expected_result,
     )
 
-    result = await instance_api.connection()
+    result = await cloud.instance.connection()
 
     assert result == expected_result
-    assert "Response for get from example.com/instance/connection (200)" in caplog.text
+    assert snapshot == extract_log_messages(caplog)
 
 
 async def test_cleanup_dns_challenge_record_endpoint_success(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
 ):
     """Test successful cleanup_dns_challenge_record endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
     aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/dns_challenge_cleanup",
+        f"https://{cloud.servicehandlers_server}/instance/dns_challenge_cleanup",
         json={},
     )
 
-    result = await instance_api.cleanup_dns_challenge_record(value="challenge-value")
+    result = await cloud.instance.cleanup_dns_challenge_record(value="challenge-value")
 
     assert result is None
-    assert (
-        "Response for post from example.com/instance/dns_challenge_cleanup (200)"
-        in caplog.text
-    )
+    assert snapshot == extract_log_messages(caplog)
 
 
 async def test_create_dns_challenge_record_endpoint_success(
     aioclient_mock: AiohttpClientMocker,
-    auth_cloud_mock: Cloud,
+    cloud: Cloud,
     caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
 ):
     """Test successful create_dns_challenge_record endpoint."""
-    instance_api = InstanceApi(auth_cloud_mock)
-
     aioclient_mock.post(
-        f"https://{API_HOSTNAME}/instance/dns_challenge_txt",
+        f"https://{cloud.servicehandlers_server}/instance/dns_challenge_txt",
         json={},
     )
 
-    result = await instance_api.create_dns_challenge_record(value="challenge-value")
+    result = await cloud.instance.create_dns_challenge_record(value="challenge-value")
 
     assert result is None
-    assert (
-        "Response for post from example.com/instance/dns_challenge_txt (200)"
-        in caplog.text
-    )
+    assert snapshot == extract_log_messages(caplog)


### PR DESCRIPTION
An attempt to make tests more natural, while mocking as little as we need.
This PR introduces a new cloud fixture and adjusts the instance_api tests to use this new approach as a demo.

Log assertions have also been moved to snapshots.