### PR TITLE
Include HTTP status code in 'Failed to parse API response' error

### DIFF
--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -310,7 +310,9 @@ class ApiBase:
         self._do_log_response(resp, data, include_path_in_log)
 
         if data is None and resp.method.upper() not in ALLOW_EMPTY_RESPONSE:
-            raise CloudApiError("Failed to parse API response") from None
+            raise CloudApiError(
+                f"Failed to parse API response (status: {resp.status})"
+            ) from None
 
         if (
             resp.status == 400

--- a/tests/__snapshots__/test_payments_api.ambr
+++ b/tests/__snapshots__/test_payments_api.ambr
@@ -21,14 +21,14 @@
   [DEBUG] hass_nabucasa.api: Response for post from api.example.com/account/payments/migrate_paypal_agreement (200) 
   '''
 # ---
-# name: test_problems_getting_connection_details[PaymentsApiError-getmockargs0-Failed to parse API response]
+# name: test_problems_getting_connection_details[PaymentsApiError-getmockargs0-Failed to parse API response (status: 500)]
   '''
   [INFO] hass_nabucasa.service_discovery: Using fallback action URL for subscription_info: https://api.example.com/account/payments/subscription_info
   [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/account/payments/subscription_info
   [DEBUG] hass_nabucasa.api: Response for get from api.example.com/account/payments/subscription_info (500) 
   '''
 # ---
-# name: test_problems_getting_connection_details[PaymentsApiError-getmockargs1-Failed to parse API response]
+# name: test_problems_getting_connection_details[PaymentsApiError-getmockargs1-Failed to parse API response (status: 429)]
   '''
   [INFO] hass_nabucasa.service_discovery: Using fallback action URL for subscription_info: https://api.example.com/account/payments/subscription_info
   [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/account/payments/subscription_info

--- a/tests/__snapshots__/test_service_discovery.ambr
+++ b/tests/__snapshots__/test_service_discovery.ambr
@@ -64,7 +64,7 @@
     'log': '''
       [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/.well-known/service-discovery
       [DEBUG] hass_nabucasa.api: Response for get from api.example.com/.well-known/service-discovery (500) 
-      [DEBUG] hass_nabucasa.service_discovery: Failed to load initial service discovery data: Failed to parse API response
+      [DEBUG] hass_nabucasa.service_discovery: Failed to load initial service discovery data: Failed to parse API response (status: 500)
       [DEBUG] hass_nabucasa.service_discovery: Scheduling service discovery refresh in 12h:1m:51s
       [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/.well-known/service-discovery
       [DEBUG] hass_nabucasa.api: Response for get from api.example.com/.well-known/service-discovery (200) 

--- a/tests/__snapshots__/test_voice_api.ambr
+++ b/tests/__snapshots__/test_voice_api.ambr
@@ -6,14 +6,14 @@
   [DEBUG] hass_nabucasa.api: Response for get from api.example.com/voice/connection_details (200) 
   '''
 # ---
-# name: test_problems_getting_connection_details[VoiceApiError-getmockargs0-Failed to parse API response]
+# name: test_problems_getting_connection_details[VoiceApiError-getmockargs0-Failed to parse API response (status: 500)]
   '''
   [INFO] hass_nabucasa.service_discovery: Using fallback action URL for voice_connection_details: https://api.example.com/voice/connection_details
   [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/voice/connection_details
   [DEBUG] hass_nabucasa.api: Response for get from api.example.com/voice/connection_details (500) 
   '''
 # ---
-# name: test_problems_getting_connection_details[VoiceApiError-getmockargs1-Failed to parse API response]
+# name: test_problems_getting_connection_details[VoiceApiError-getmockargs1-Failed to parse API response (status: 429)]
   '''
   [INFO] hass_nabucasa.service_discovery: Using fallback action URL for voice_connection_details: https://api.example.com/voice/connection_details
   [DEBUG] hass_nabucasa.api: Sending GET request to api.example.com/voice/connection_details

--- a/tests/test_account_api.py
+++ b/tests/test_account_api.py
@@ -22,12 +22,12 @@ from tests.utils.aiohttp import AiohttpClientMocker
         [
             AccountApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             AccountApiError,
             {"status": 429, "text": "Too fast"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 429)",
         ],
         [
             AccountApiError,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -119,7 +119,9 @@ async def test_empty_response_handling_disallowed_methods(
         status=200,
     )
 
-    with pytest.raises(CloudApiError, match="Failed to parse API response"):
+    with pytest.raises(
+        CloudApiError, match=r"Failed to parse API response \(status: 200\)"
+    ):
         await test_api._call_cloud_api(
             path="/test",
             method=method,

--- a/tests/test_instance_api.py
+++ b/tests/test_instance_api.py
@@ -23,12 +23,12 @@ API_HOSTNAME = "example.com"
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             InstanceApiError,
             {"status": 429, "text": "Too fast"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 429)",
         ],
         [
             InstanceApiError,
@@ -262,7 +262,7 @@ async def test_ping_targets_endpoint_success(
         [
             InstanceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             InstanceApiError,

--- a/tests/test_payments_api.py
+++ b/tests/test_payments_api.py
@@ -29,12 +29,12 @@ if TYPE_CHECKING:
         [
             PaymentsApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             PaymentsApiError,
             {"status": 429, "text": "Too fast"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 429)",
         ],
         [
             PaymentsApiError,
@@ -68,7 +68,7 @@ async def test_problems_getting_connection_details(
         **getmockargs,
     )
 
-    with pytest.raises(exception, match=exception_msg):
+    with pytest.raises(exception, match=re.escape(exception_msg)):
         await cloud.payments.subscription_info()
 
     assert extract_log_messages(caplog) == snapshot

--- a/tests/test_service_discovery.py
+++ b/tests/test_service_discovery.py
@@ -72,12 +72,12 @@ def add_test_api_action_to_service_discovery():
         [
             ServiceDiscoveryError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             ServiceDiscoveryError,
             {"status": 429, "text": "Too fast"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 429)",
         ],
         [
             ServiceDiscoveryError,
@@ -233,7 +233,8 @@ async def test_load_service_discovery_data_raises_when_no_cache_and_failure(
     )
 
     with pytest.raises(
-        ServiceDiscoveryError, match=re.escape("Failed to parse API response")
+        ServiceDiscoveryError,
+        match=re.escape("Failed to parse API response (status: 500)"),
     ):
         await cloud.service_discovery._load_service_discovery_data()
 

--- a/tests/test_voice_api.py
+++ b/tests/test_voice_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientError
@@ -25,12 +26,12 @@ if TYPE_CHECKING:
         [
             VoiceApiError,
             {"status": 500, "text": "Internal Server Error"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 500)",
         ],
         [
             VoiceApiError,
             {"status": 429, "text": "Too fast"},
-            "Failed to parse API response",
+            "Failed to parse API response (status: 429)",
         ],
         [
             VoiceApiError,
@@ -64,7 +65,7 @@ async def test_problems_getting_connection_details(
         **getmockargs,
     )
 
-    with pytest.raises(exception, match=exception_msg):
+    with pytest.raises(exception, match=re.escape(exception_msg)):
         await cloud.voice_api.connection_details()
 
     assert extract_log_messages(caplog) == snapshot


### PR DESCRIPTION
Append the response status to the CloudApiError message so it reads `"Failed to parse API response (status: <code>)"`, making it easier to tell which kind of response could not be parsed.
