### PR TITLE
Bump snitun to 0.46.1 and adopt the new SniTunClientAioHttp API

### DIFF
--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -405,7 +405,7 @@ class RemoteUI:
 
         _LOGGER.debug("Starting SniTun")
         is_cloud_request.set(True)
-        await self._snitun.start(False, self._recreate_backend)
+        await self._snitun.start()
         self.cloud.client.dispatcher_message(const.DISPATCH_REMOTE_BACKEND_UP)
 
         _LOGGER.debug(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pycognito==2024.5.1",
     "PyJWT>=2.8.0",
     "requests>=2.0,<3",
-    "snitun==0.45.2",
+    "snitun==0.46.1",
     "voluptuous>=0.15",
     "webrtc-models<1.0.0",
     "yarl>=1.20,<2",

--- a/tests/common.py
+++ b/tests/common.py
@@ -266,7 +266,7 @@ class MockSnitun:
         self.init_kwarg = None
         self.wait_task = asyncio.Event()
 
-        self.start_whitelist = None
+        self.start_access_list = None
         self.start_endpoint_connection_error_callback = None
 
     @property
@@ -280,11 +280,11 @@ class MockSnitun:
 
     async def start(
         self,
-        whitelist: bool = False,
+        access_list: Any | None = None,
         endpoint_connection_error_callback: Coroutine[Any, Any, None] | None = None,
     ):
         """Start snitun."""
-        self.start_whitelist = whitelist
+        self.start_access_list = access_list
         self.start_endpoint_connection_error_callback = (
             endpoint_connection_error_callback
         )

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -151,8 +151,10 @@ async def test_load_backend_exists_cert(
         "snitun_port": 443,
     }
 
-    assert snitun_mock.start_whitelist is not None
-    assert snitun_mock.start_endpoint_connection_error_callback is not None
+    # snitun is started with the new API: no access list and no deprecated
+    # endpoint_connection_error_callback.
+    assert snitun_mock.start_access_list is None
+    assert snitun_mock.start_endpoint_connection_error_callback is None
 
     await asyncio.sleep(0.1)
     assert snitun_mock.call_connect


### PR DESCRIPTION
## What

Bumps `snitun` `0.45.2` → `0.46.1` and migrates `RemoteUI` to the reworked `SniTunClientAioHttp` API.

snitun 0.46.x reworked `SniTunClientAioHttp` around a `TransportConnector`, which changes `start()`:

- The first argument is no longer a `whitelist: bool` — it is now an optional `AccessList` (default `None`). We previously passed `False` (i.e. no whitelist), which maps to the new default of no access list.
- `endpoint_connection_error_callback` is **deprecated and no longer used** by snitun; passing it now raises a `DeprecationWarning`. It is dropped from the `start()` call.

So `await self._snitun.start(False, self._recreate_backend)` becomes `await self._snitun.start()`.

`_recreate_backend` is **not** removed — it is still invoked by the certificate-renewal flow (`remote.py`), so it remains live code.

## Tests

- `MockSnitun.start` updated to the new signature (`access_list` instead of `whitelist`).
- The `test_load_backend_exists_cert` assertions now verify the new no-argument call: no access list and no deprecated callback passed.

## ⚠️ Before merging

- [ ] **snitun 0.46.1 must be published to PyPI first.** At the time of writing it exists only as a GitHub release; CI will fail to install the `==0.46.1` pin until it is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)