### PR TITLE
Add Node.js and GitHub CLI features to devcontainer

### DIFF
--- a/.devcontainer-lock.json
+++ b/.devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {
+      "version": "1.0.5",
+      "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
+      "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:2.0.0": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    }
+  }
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,6 +11,8 @@
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.14"
     },
+    "ghcr.io/devcontainers/features/node:2.0.0": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/anthropics/devcontainer-features/claude-code:1.0": {}
   },
   "customizations": {


### PR DESCRIPTION
## Summary

- Add the `node` devcontainer feature ⚠️ **required fix**
- Add the `github-cli` feature for the `gh`-based workflow
- Add `.devcontainer-lock.json` to pin resolved feature versions

## ⚠️ The current devcontainer will not work without Node.js

The `ghcr.io/anthropics/devcontainer-features/claude-code` feature is already in the devcontainer, but **Claude Code requires Node.js to run** and the base image (`mcr.microsoft.com/vscode/devcontainers/base:ubuntu`) does not include it. Without the `node` feature, the container builds but Claude Code is effectively unusable. This PR adds `ghcr.io/devcontainers/features/node:2.0.0` to fix that.

The `github-cli` feature is added so `gh` is available for the PR/issue workflow inside the container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)