### PR TITLE
Clarify subscription log message to 'No active subscription found'

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -617,7 +617,7 @@ class Cloud(Generic[_ClientT]):
             _LOGGER.debug(err, exc_info=err)
 
         if billing_plan_type is None or billing_plan_type == "no_subscription":
-            _LOGGER.info("No subscription found")
+            _LOGGER.info("No active subscription found")
             self.async_initialize_subscription_reconnection_handler(
                 SubscriptionReconnectionReason.NO_SUBSCRIPTION
             )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -471,7 +471,7 @@ async def test_subscription_reconnect_for_no_subscription(
         await cl.initialize()
         await start_done_event.wait()
 
-    assert "No subscription found" in caplog.text
+    assert "No active subscription found" in caplog.text
     assert "Stopping subscription reconnection handler" in caplog.text
 
 


### PR DESCRIPTION
The condition also fires when an inactive subscription exists (billing_plan_type == "no_subscription"), so 'No active subscription found' more accurately describes the state.
