### PR TITLE
Upgrade snitun dependency to 0.47.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pycognito==2024.5.1",
     "PyJWT>=2.8.0",
     "requests>=2.0,<3",
-    "snitun==0.46.1",
+    "snitun==0.47.0",
     "voluptuous>=0.15",
     "webrtc-models<1.0.0",
     "yarl>=1.20,<2",


### PR DESCRIPTION
## Summary
Updates the snitun dependency from 0.46.1 to 0.47.0 to incorporate the latest improvements and bug fixes from the upstream project.

https://github.com/NabuCasa/snitun/releases/tag/0.47.0

## Changes
- Bumped `snitun` version constraint in `pyproject.toml` from `0.46.1` to `0.47.0`

## Details
This is a minor version bump of the snitun library, which is used for remote UI tunnel connectivity via SniTun integration. The upgrade brings in the latest upstream improvements while maintaining compatibility with the existing codebase.
