### PR TITLE
fix(remote): make certificate flow tolerate transient DNS failures

### DIFF
--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -557,7 +557,6 @@ class AcmeHandler:
                         value=dns_challenges[-1].validation,
                     )
             except (TimeoutError, InstanceApiError) as err:
-                # Challenge already answered; leftover DNS record is not fatal
                 _LOGGER.warning(
                     "Failed to clean up challenge from NabuCasa DNS: %s", err
                 )

--- a/hass_nabucasa/acme.py
+++ b/hass_nabucasa/acme.py
@@ -25,6 +25,7 @@ import OpenSSL
 from requests.exceptions import RequestException
 
 from .const import CertificateStatus
+from .instance_api import InstanceApiError
 from .utils import seconds_as_dhms, utcnow
 
 FILE_ACCOUNT_KEY = "acme_account.pem"
@@ -517,7 +518,7 @@ class AcmeHandler:
                             value=challenge.validation
                         )
                     self._update_status(CertificateStatus.CHALLENGE_DNS_UPDATED)
-                except TimeoutError, AssertionError:
+                except TimeoutError, AssertionError, InstanceApiError:
                     self._update_status(CertificateStatus.CHALLENGE_DNS_FAILED)
                     raise AcmeNabuCasaError(
                         "Can't set challenge token to NabuCasa DNS!",
@@ -555,8 +556,11 @@ class AcmeHandler:
                     await self.cloud.instance.cleanup_dns_challenge_record(
                         value=dns_challenges[-1].validation,
                     )
-            except TimeoutError:
-                _LOGGER.error("Failed to clean up challenge from NabuCasa DNS!")
+            except (TimeoutError, InstanceApiError) as err:
+                # Challenge already answered; leftover DNS record is not fatal
+                _LOGGER.warning(
+                    "Failed to clean up challenge from NabuCasa DNS: %s", err
+                )
 
         # Finish validation
         self._update_status(CertificateStatus.CERTIFICATE_FINALIZING)

--- a/hass_nabucasa/remote.py
+++ b/hass_nabucasa/remote.py
@@ -644,7 +644,7 @@ class RemoteUI:
 
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected error in Remote UI loop")
-                raise
+                await asyncio.sleep(10)
 
         _LOGGER.debug("Stopping Remote UI loop")
         await self.close_backend()

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,9 +1,10 @@
 """Test ACME handler functionality."""
 
 from socket import gaierror
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from acme import messages
+import aiohttp
 import pytest
 from requests.exceptions import RequestException
 
@@ -13,8 +14,11 @@ from hass_nabucasa.acme import (
     AcmeClientError,
     AcmeHandler,
     AcmeJWSVerificationError,
+    AcmeNabuCasaError,
+    ChallengeHandler,
     _raise_if_jws_verification_failed,
 )
+from tests.utils.aiohttp import AiohttpClientMocker
 
 
 @pytest.mark.parametrize(
@@ -262,3 +266,80 @@ def test_acme_handler_deactivate_account_network_errors(
 
         with pytest.raises(AcmeClientError, match="Can't deactivate account"):
             handler._deactivate_account()
+
+
+async def test_issue_certificate_dns_challenge_set_failure_raises_acme_error(
+    cloud: Cloud,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """A DNS blip creating the challenge record must surface as AcmeNabuCasaError.
+
+    Regression test: this call site used to only catch TimeoutError and
+    AssertionError, so a DNS/connection failure (which surfaces as
+    InstanceApiError) leaked past it and killed the calling task instead of
+    being handled as an expected, retryable ACME failure.
+    """
+    handler = AcmeHandler(cloud, ["test.example.com"], "test@example.com", Mock())
+    challenge = ChallengeHandler(Mock(), Mock(), Mock(), "test-validation")
+
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/dns_challenge_txt",
+        exc=aiohttp.ClientConnectionError("Timeout while contacting DNS servers"),
+    )
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/dns_challenge_cleanup",
+        json={},
+    )
+
+    with (
+        patch.object(handler, "_create_client"),
+        patch.object(handler, "_generate_csr", return_value=b"csr"),
+        patch.object(handler, "_create_order", return_value=Mock()),
+        patch.object(handler, "_start_challenge", return_value=[challenge]),
+        patch.object(handler, "_answer_challenge") as mock_answer,
+        patch.object(handler, "_finish_challenge") as mock_finish,
+        pytest.raises(AcmeNabuCasaError, match="Can't set challenge token"),
+    ):
+        await handler.issue_certificate()
+
+    mock_answer.assert_not_called()
+    mock_finish.assert_not_called()
+
+
+async def test_issue_certificate_dns_cleanup_failure_is_not_fatal(
+    cloud: Cloud,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """A DNS blip cleaning up the challenge record must not abort issuance.
+
+    Regression test: by the time cleanup runs, the challenge has already been
+    answered, so the certificate can still finalize even if the leftover DNS
+    record isn't removed. This call site used to only catch TimeoutError, so
+    a DNS/connection failure (InstanceApiError) leaked past it and killed the
+    calling task after the hard work was already done.
+    """
+    handler = AcmeHandler(cloud, ["test.example.com"], "test@example.com", Mock())
+    challenge = ChallengeHandler(Mock(), Mock(), Mock(), "test-validation")
+
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/dns_challenge_txt",
+        json={},
+    )
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/dns_challenge_cleanup",
+        exc=aiohttp.ClientConnectionError("Timeout while contacting DNS servers"),
+    )
+
+    with (
+        patch.object(handler, "_create_client"),
+        patch.object(handler, "_generate_csr", return_value=b"csr"),
+        patch.object(handler, "_create_order", return_value=Mock()),
+        patch.object(handler, "_start_challenge", return_value=[challenge]),
+        patch.object(handler, "_answer_challenge"),
+        patch.object(handler, "_finish_challenge") as mock_finish,
+        patch.object(handler, "load_certificate", AsyncMock()),
+        patch("hass_nabucasa.acme.asyncio.sleep", AsyncMock()),
+    ):
+        await handler.issue_certificate()
+
+    mock_finish.assert_called_once()

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -555,6 +555,85 @@ async def test_get_certificate_details(
     assert certificate.fingerprint == "ffff"
 
 
+async def test_certificate_task_survives_unexpected_error(
+    cloud: Cloud,
+    acme_mock: MockAcme,
+    aioclient_mock: AiohttpClientMocker,
+    snitun_mock: MockSnitun,
+    caplog: pytest.LogCaptureFixture,
+    mock_timing: None,
+) -> None:
+    """An unhandled exception in the loop must not kill the task permanently.
+
+    Regression test: _certificate_handler used to re-raise any exception it
+    didn't have a specific handler for, which ended the asyncio.Task for
+    good. Nothing but a full Core restart or a config-entry reload could
+    produce another attempt. It should instead log, back off, and retry.
+    """
+    valid = utcnow() + timedelta(days=1)
+
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/register",
+        json={
+            "domain": "test.dui.nabu.casa",
+            "email": "test@nabucasa.inc",
+            "server": "rest-remote.nabu.casa",
+        },
+    )
+    aioclient_mock.post(
+        f"https://{cloud.api_server}/instance/snitun_token",
+        json={
+            "token": "test-token",
+            "server": "rest-remote.nabu.casa",
+            "valid": valid.timestamp(),
+            "throttling": 400,
+        },
+    )
+
+    acme_mock.expire_date = valid
+
+    original_issue_certificate = acme_mock.issue_certificate
+    attempts = 0
+
+    async def flaky_issue_certificate() -> None:
+        """Fail exactly once, simulating a DNS blip, then behave normally."""
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("simulated unexpected DNS blip")
+        await original_issue_certificate()
+
+    acme_mock.issue_certificate = flaky_issue_certificate
+
+    with (
+        patch("hass_nabucasa.utils.next_midnight", return_value=0),
+        patch("random.randint", return_value=0),
+    ):
+        acme_task = cloud.remote._acme_task = asyncio.create_task(
+            cloud.remote._certificate_handler(),
+        )
+        # mock_timing collapses every asyncio.sleep() call (both the one
+        # below and the loop's internal retry backoff) to ~0.001s of real
+        # time, so poll in short rounds instead of one fixed wait: a single
+        # await is a coin flip against the handler's own retry-backoff timer
+        # firing first.
+        for _ in range(100):
+            if attempts >= 2:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("certificate handler never retried after the error")
+
+        assert "Unexpected error in Remote UI loop" in caplog.text
+        assert acme_mock.call_issue
+        assert snitun_mock.call_start
+        assert not acme_task.done()
+
+        await cloud.remote.stop()
+        await asyncio.sleep(0.1)
+        assert acme_task.done()
+
+
 async def test_certificate_task_no_backend(
     cloud: Cloud,
     acme_mock: MockAcme,


### PR DESCRIPTION

## Summary

`_certificate_handler`, the background loop that owns Remote UI's ACME
certificate lifecycle, has no tolerance for a single transient DNS failure
anywhere in the certificate issuance sequence. If any network call inside
`issue_certificate()` hits a DNS blip that the surrounding code doesn't have a
specific handler for, the exception propagates all the way up, and the loop's
outer exception handler re-raises it. That ends the `asyncio.Task` permanently.
Nothing but a full Home Assistant Core restart or a `cloud` config-entry reload
produces another attempt; the public recovery path (toggling Remote UI off and
on, which calls `RemoteUI.connect()`/ `disconnect()`) does not retry certificate
issuance and just raises `RemoteNotConnected` again. An HA Core restart may not
move the needle here: that causes every system and integration to look up DNS
resources they need, and on low power devices (I'm running on an rPi 4) that
thundering herd can cause transient DNS failures. At that point
\_certificate_handler is effectively stalled forever. The practical result is that a new
setup of HA Cloud may hang, displaying "Preparing" in perpetuity with no feedback
to the user about why their Cloud setup cannot complete.

This was reproduced on a live instance: a DNS resolver hiccup during
`cleanup_dns_challenge_record` (the step that removes the now-unneeded ACME
challenge TXT record, which runs after the challenge has already been answered)
killed the certificate loop outright, leaving `remote_ui` stuck `unavailable`
through multilple Core restarts until one happened to land outside a bad DNS
window.

## Root cause

Two `except` clauses in `acme.py`'s `issue_certificate()` are narrower than the
exceptions the calls they guard can actually raise:

- `create_dns_challenge_record` (setting the DNS-01 challenge record) is wrapped
  in `except TimeoutError, AssertionError:`.
- `cleanup_dns_challenge_record` (removing it afterward) is wrapped in
  `except TimeoutError:`.

Both calls go through `InstanceApi`, whose `api_exception_handler` decorator
normalizes network and connection failures (including DNS resolution failures,
which aiohttp surfaces as `ClientError` subclasses) into `InstanceApiError`.
That type is not a `TimeoutError` and not an `AssertionError`, so a DNS blip
during either call is not caught by either `except` clause. It propagates out of
`issue_certificate()` uncaught.

From there it's not caught by `load_backend()` either, since that only catches
`AcmeJWSVerificationError` and `AcmeClientError`, and `InstanceApiError` is
unrelated to that hierarchy. It reaches `_certificate_handler`'s outer handler:

```python
except Exception:  # pylint: disable=broad-except
    _LOGGER.exception("Unexpected error in Remote UI loop")
    raise
```

which logs it and re-raises, ending the task for good.

Separately, even for failures the code already knows how to handle,
`_certificate_handler`'s "give up and re-raise" behavior on anything
unanticipated means any bug or edge case in this loop, not just DNS ones,
permanently stops all future certificate work until an external trigger restarts
it. There's no backoff-and-retry for that class of failure, even though the loop
already retries on a flat 10-second interval when `load_backend()` fails in one
of the ways it already anticipates.

## Fix

1. **`create_dns_challenge_record`**: widen the `except` clause to include
   `InstanceApiError`, so a DNS/connection failure here converts to
   `AcmeNabuCasaError` like every other expected ACME failure, instead of
   leaking as a raw exception.

2. **`cleanup_dns_challenge_record`**: widen the `except` clause to include
   `InstanceApiError` and treat the failure as non-fatal (log a warning and
   continue to certificate finalization) rather than letting it abort issuance.
   The certificate can still finalize even if the leftover DNS record isn't
   removed.

3. **`_certificate_handler`**: stop re-raising on an unhandled exception. Log it
   (as before, with the full traceback) and back off for the same flat 10
   seconds the loop already uses for its other retry path, then let the
   `while True:` loop continue instead of dying. This makes the loop resilient
   to failure modes beyond the two specifically fixed above, without inventing
   new retry machinery: it reuses the interval and philosophy the code already
   has.

## Testing

Two new tests in `tests/test_acme.py` exercise `issue_certificate()` directly,
with the internal ACME-library calls mocked out and the actual
DNS-challenge-record HTTP calls going through the test's `aioclient_mock`:

- `test_issue_certificate_dns_challenge_set_failure_raises_acme_error`:
  simulates a DNS blip during `create_dns_challenge_record` and asserts it
  surfaces as `AcmeNabuCasaError` (not a raw `InstanceApiError`), and that the
  flow stops there (`_answer_challenge`/`_finish_challenge` never run).
- `test_issue_certificate_dns_cleanup_failure_is_not_fatal`: simulates the same
  blip during `cleanup_dns_challenge_record` and asserts `issue_certificate()`
  completes without raising, reaching `_finish_challenge`.

One new test in `tests/test_remote.py`,
`test_certificate_task_survives_unexpected_error`, drives the real
`_certificate_handler()` loop with a mocked ACME handler whose
`issue_certificate()` raises an unrelated `RuntimeError` on its first call
(standing in for any exception type this loop doesn't have a specific handler
for) and succeeds on the second. It asserts the loop logs the failure, backs
off, retries, and the `asyncio.Task` is still running afterward, where before
this fix it would already be dead with the `RuntimeError` as its result.

All three tests were verified to fail against the pre-fix code (confirmed by
temporarily reverting each source change and re-running them) before being
confirmed to pass against the fix. Full existing suite (484 tests) still passes;
`ruff check`, `ruff format --check`, and `mypy hass_nabucasa` are clean.
