### PR TITLE
Map PreSignUp Lambda validation errors to clean auth errors

### DIFF
--- a/hass_nabucasa/auth/cognito.py
+++ b/hass_nabucasa/auth/cognito.py
@@ -401,9 +401,9 @@ def _map_aws_exception(err: ClientError | BotoCoreError) -> CloudError:
             err.kwargs.get("error", str(err))
         )
 
-    error = err.response.get("Error", {})
-    error_code = error.get("Code", "")
-    error_message = error.get("Message", "")
+    error = err.response["Error"]
+    error_code = error["Code"]
+    error_message = error["Message"]
 
     # Strip Cognito's Lambda wrapper: "<trigger> failed with error ||<message>".
     error_message = error_message.rsplit("||", 1)[-1].strip()

--- a/hass_nabucasa/auth/cognito.py
+++ b/hass_nabucasa/auth/cognito.py
@@ -400,9 +400,22 @@ def _map_aws_exception(err: ClientError | BotoCoreError) -> CloudError:
         return AWS_EXCEPTIONS.get(err.__class__.__name__, UnknownError)(
             err.kwargs.get("error", str(err))
         )
-    return AWS_EXCEPTIONS.get(err.response["Error"]["Code"], UnknownError)(
-        err.response["Error"]["Message"]
-    )
+
+    error = err.response.get("Error", {})
+    error_code = error.get("Code", "")
+    error_message = error.get("Message", "")
+
+    # Strip Cognito's Lambda wrapper: "<trigger> failed with error ||<message>".
+    error_message = error_message.rsplit("||", 1)[-1].strip()
+
+    # A PreSignUp Lambda reports "already exists" as UserLambdaValidationException.
+    if (
+        error_code == "UserLambdaValidationException"
+        and "already exists" in error_message.lower()
+    ):
+        return UserExists(error_message)
+
+    return AWS_EXCEPTIONS.get(error_code, UnknownError)(error_message)
 
 
 @lru_cache(maxsize=2)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -186,6 +186,43 @@ async def test_register_fails(mock_cognito, cloud_mock):
         await auth.async_register("email@home-assistant.io", "password")
 
 
+async def test_register_presignup_already_exists_maps_to_user_exists(
+    mock_cognito,
+    cloud_mock,
+):
+    """Test a PreSignUp Lambda "already exists" error maps to UserExists.
+
+    Cognito wraps it as a generic UserLambdaValidationException, not the plain
+    UsernameExistsException, so it must not leak as an UnknownError, and the
+    internal "PreSignUp failed with error ||" wrapper must be stripped.
+    """
+    mock_cognito.register.side_effect = aws_error(
+        "UserLambdaValidationException",
+        "PreSignUp failed with error ||An account for this email already exists.",
+    )
+    auth = auth_api.CognitoAuth(cloud_mock)
+    with pytest.raises(auth_api.UserExists) as err:
+        await auth.async_register("email@home-assistant.io", "password")
+
+    assert str(err.value) == "An account for this email already exists."
+
+
+async def test_register_other_lambda_validation_strips_wrapper(
+    mock_cognito,
+    cloud_mock,
+):
+    """Test an unrelated Lambda validation error keeps only the clean message."""
+    mock_cognito.register.side_effect = aws_error(
+        "UserLambdaValidationException",
+        "PreSignUp failed with error ||Sign ups are disabled.",
+    )
+    auth = auth_api.CognitoAuth(cloud_mock)
+    with pytest.raises(auth_api.UnknownError) as err:
+        await auth.async_register("email@home-assistant.io", "password")
+
+    assert str(err.value) == "Sign ups are disabled."
+
+
 async def test_resend_email_confirm(mock_cognito, cloud_mock):
     """Test starting forgot password flow."""
     auth = auth_api.CognitoAuth(cloud_mock)


### PR DESCRIPTION
## Summary

Registering an account could surface a raw internal error to the UI:

> Unexpected error: PreSignUp failed with error ||An account for this email already exists…

When a Cognito **PreSignUp Lambda** trigger rejects sign-up (e.g. the account already exists), Cognito returns a generic `UserLambdaValidationException` wrapping the Lambda's own message as `"<trigger> failed with error ||<message>"` — not the native `UsernameExistsException`. `_map_aws_exception` only mapped `UsernameExistsException`, so this fell through to `UnknownError` and the raw wrapper reached the frontend as "Unexpected error: …".

## Change

In `hass_nabucasa/auth/cognito.py`, `_map_aws_exception` now:

1. **Strips the Cognito wrapper** — keeps only the text after `||`, so the internal `"<trigger> failed with error"` prefix is never forwarded for any Lambda rejection.
2. **Maps the "already exists" case to `UserExists`**, so callers get the normal "already registered" handling instead of a generic "Unexpected error". If the backend ever changes that wording, the match misses and it degrades to a clean message (thanks to the strip), not the raw wrapper.

## Notes

- This is the **client-side safety net**. The durable fix is the backend PreSignUp Lambda surfacing the "already exists" case as the native `UsernameExistsException` (or a stable structured error). Both are captured in **CLOUD-707**.
- The `"already exists"` match is intentionally narrow so unrelated Lambda rejections (e.g. "sign-ups disabled") aren't mislabelled — they still map to `UnknownError`, but with the clean, unwrapped message.

## Tests

- `test_register_presignup_already_exists_maps_to_user_exists` — the wrapped "already exists" error maps to `UserExists` with the stripped message.
- `test_register_other_lambda_validation_strips_wrapper` — an unrelated Lambda validation error stays `UnknownError` but keeps only the clean message.

`scripts/test` → all pass; `scripts/lint` → ruff, ruff-format, codespell, pylint, mypy all pass.

Refs CLOUD-707.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
