### PR TITLE
Reject login when the id token has no subscription claim

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -348,17 +348,9 @@ class Cloud(Generic[_ClientT]):
         access_token: str,
         refresh_token: str | None = None,
     ) -> asyncio.Task | None:
-        """Update the id and access token.
-
-        A token without a subscription expiration claim means the account is
-        not usable yet: still being provisioned, or otherwise broken. Reject it
-        before storing anything, so a broken token never overwrites a good one
-        and the instance is never left half-logged-in on an unusable account.
-        On login this surfaces as AccountNotReady; on a token renewal it is
-        caught by the caller, which keeps the previous (valid) token.
-        """
+        """Update the id and access token."""
         if self._decode_claims(id_token).get("custom:sub-exp") is None:
-            raise AccountNotReady
+            raise AccountNotReady("Account is still being provisioned")
 
         self.id_token = id_token
         self.access_token = access_token

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -34,6 +34,7 @@ from .api import (
     CloudApiTimeoutError,
 )
 from .auth import (
+    AccountNotReady,
     AuthTimeoutError,
     CognitoAuth,
     InvalidTotpCode,
@@ -110,6 +111,7 @@ from .voice_api import VoiceApi, VoiceApiError
 __all__ = [
     "MODE_DEV",
     "AccountApiError",
+    "AccountNotReady",
     "AccountsApi",
     "AccountsApiError",
     "AlexaAccessTokenDetails",
@@ -346,7 +348,18 @@ class Cloud(Generic[_ClientT]):
         access_token: str,
         refresh_token: str | None = None,
     ) -> asyncio.Task | None:
-        """Update the id and access token."""
+        """Update the id and access token.
+
+        A token without a subscription expiration claim means the account is
+        not usable yet: still being provisioned, or otherwise broken. Reject it
+        before storing anything, so a broken token never overwrites a good one
+        and the instance is never left half-logged-in on an unusable account.
+        On login this surfaces as AccountNotReady; on a token renewal it is
+        caught by the caller, which keeps the previous (valid) token.
+        """
+        if self._decode_claims(id_token).get("custom:sub-exp") is None:
+            raise AccountNotReady
+
         self.id_token = id_token
         self.access_token = access_token
         if refresh_token is not None:

--- a/hass_nabucasa/auth/__init__.py
+++ b/hass_nabucasa/auth/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .cognito import (
+    AccountNotReady,
     AuthTimeoutError,
     CloudConnectionError,
     CloudError,
@@ -18,6 +19,7 @@ from .cognito import (
 )
 
 __all__ = [
+    "AccountNotReady",
     "AuthTimeoutError",
     "CloudConnectionError",
     "CloudError",

--- a/hass_nabucasa/auth/cognito.py
+++ b/hass_nabucasa/auth/cognito.py
@@ -67,13 +67,7 @@ class UserNotConfirmed(CloudError):
 
 
 class AccountNotReady(CloudError):
-    """Raised when the account's subscription has not finished provisioning.
-
-    Authentication succeeded, but the id token does not yet carry the
-    subscription expiration claim because provisioning is still in progress.
-    Login must not complete until it does, so this is a login precondition
-    much like UserNotConfirmed rather than an error.
-    """
+    """Raised when the account's subscription has not finished provisioning."""
 
 
 class CloudConnectionError(CloudError):

--- a/hass_nabucasa/auth/cognito.py
+++ b/hass_nabucasa/auth/cognito.py
@@ -66,6 +66,16 @@ class UserNotConfirmed(CloudError):
     """Raised when a user has not confirmed email yet."""
 
 
+class AccountNotReady(CloudError):
+    """Raised when the account's subscription has not finished provisioning.
+
+    Authentication succeeded, but the id token does not yet carry the
+    subscription expiration claim because provisioning is still in progress.
+    Login must not complete until it does, so this is a login precondition
+    much like UserNotConfirmed rather than an error.
+    """
+
+
 class CloudConnectionError(CloudError):
     """Raised when unable to connect to the cloud."""
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -133,6 +133,18 @@ async def test_login(mock_cognito, mock_cloud):
     )
 
 
+async def test_login_account_not_ready(mock_cognito, mock_cloud):
+    """Test login surfaces AccountNotReady instead of swallowing it."""
+    auth = auth_api.CognitoAuth(mock_cloud)
+    mock_cognito.id_token = "test_id_token"
+    mock_cognito.access_token = "test_access_token"
+    mock_cognito.refresh_token = "test_refresh_token"
+    mock_cloud.update_token.side_effect = auth_api.AccountNotReady
+
+    with pytest.raises(auth_api.AccountNotReady):
+        await auth.async_login("user", "pass")
+
+
 async def test_login_with_check_connection(mock_cognito, mock_cloud):
     """Test login with connection check."""
     auth = auth_api.CognitoAuth(mock_cloud)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -315,12 +315,37 @@ def test_subscription_not_expired(cl: cloud.Cloud):
 
 async def test_claims_decoding(cl: cloud.Cloud):
     """Test decoding claims."""
-    payload = {"cognito:username": "abc123", "some": "value"}
+    payload = {
+        "cognito:username": "abc123",
+        "custom:sub-exp": "2099-01-01",
+        "some": "value",
+    }
     encoded_token = cloud.jwt.encode(payload, key="secret")
 
     await cl.update_token(encoded_token, None)
     assert cl.claims == payload
     assert cl.username == "abc123"
+
+
+async def test_update_token_raises_account_not_ready_without_claim(cl: cloud.Cloud):
+    """Test a token without a subscription claim is refused.
+
+    The account is not usable yet, so nothing may be stored and the instance
+    must not be left half-logged-in.
+    """
+    token_without_claim = cloud.jwt.encode({"cognito:username": "abc"}, key="secret")
+
+    with pytest.raises(cloud.AccountNotReady):
+        await cl.update_token(
+            token_without_claim,
+            "test-access-token",
+            "test-refresh-token",
+        )
+
+    assert cl.id_token is None
+    assert cl.access_token is None
+    assert cl.refresh_token is None
+    assert not cl.is_logged_in
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`Cloud.update_token` writes the tokens and sets `id_token` before it reads the subscription expiration claim. If a freshly authenticated id token has no `custom:sub-exp` claim, the instance is left "logged in" with a token it can't use, and the next access to `expiration_date` / `subscription_expired` raises `KeyError`, which keeps failing until the stored auth is removed.

This rejects such a token up front — `update_token` raises a new typed `AccountNotReady` (`CloudError`) before storing anything:

- **On login**, it propagates so login fails cleanly and `is_logged_in` stays `False` (nothing persisted).
- **On renewal**, the caller already catches `CloudError`, so a valid token is never overwritten by an unusable one and renewal simply retries.
