### PR TITLE
Export RemoteNotConnected from the package root

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -85,7 +85,7 @@ from .payments_api import (
     PaymentsApiError,
     SubscriptionInfo,
 )
-from .remote import RemoteLatencyLocationResult, RemoteUI
+from .remote import RemoteLatencyLocationResult, RemoteNotConnected, RemoteUI
 from .service_discovery import (
     ServiceDiscovery,
     ServiceDiscoveryAction,
@@ -151,6 +151,7 @@ __all__ = [
     "PasswordChangeRequired",
     "PaymentsApiError",
     "RemoteLatencyLocationResult",
+    "RemoteNotConnected",
     "ServiceDiscovery",
     "ServiceDiscoveryAction",
     "ServiceDiscoveryError",


### PR DESCRIPTION
## Summary

Re-export `RemoteNotConnected` from the top-level `hass_nabucasa` package so consumers (Home Assistant) can import it directly:

```python
from hass_nabucasa import RemoteNotConnected
```

`RemoteNotConnected` is defined in `hass_nabucasa/remote.py` and raised by the Remote UI when a request-connection is attempted without a backend. It was only reachable via `hass_nabucasa.remote.RemoteNotConnected`; this adds it to the package root's imports and `__all__`, consistent with the other exported error types.

## Change

- `hass_nabucasa/__init__.py`: add `RemoteNotConnected` to `from .remote import …` and to `__all__`.

No behavior change.

- `scripts/test` → all pass
- `scripts/lint` → ruff, ruff-format, codespell, pylint, mypy all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
