### PR TITLE
Add auto flag to login events and a LOGIN_FAILED event with a reason

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -486,7 +486,8 @@ class Cloud(Generic[_ClientT]):
         a background task retries login with backoff until confirmed, else gives up
         after ~a day. On success a LOGIN event is published. If the task gives up
         without logging in (schedule exhausted, a fatal CloudError, or an unexpected
-        exception), an AUTO_LOGIN_FAILED event is published so the caller can stop waiting.
+        exception), an AUTO_LOGIN_FAILED event is published so the caller can stop
+        waiting.
         """
         # Normalize email, so the auto-login uses the same value as the registration
         email = email.lower()

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -73,6 +73,8 @@ from .events import (
     CloudEventType,
     CloudhookCreatedEvent,
     CloudhookDeletedEvent,
+    LoginEvent,
+    LoginFailedEvent,
 )
 from .exceptions import (
     CloudError,
@@ -157,6 +159,8 @@ __all__ = [
     "InstanceApiError",
     "InstanceConnectionDetails",
     "InvalidTotpCode",
+    "LoginEvent",
+    "LoginFailedEvent",
     "MFARequired",
     "MigratePaypalAgreementInfo",
     "NabuCasaAuthenticationError",
@@ -439,12 +443,17 @@ class Cloud(Generic[_ClientT]):
         return self.client.loop.run_in_executor(None, callback, *args)
 
     async def login(
-        self, email: str, password: str, *, check_connection: bool = False
+        self,
+        email: str,
+        password: str,
+        *,
+        check_connection: bool = False,
+        auto: bool = False,
     ) -> None:
         """Log a user in."""
         await self.auth.async_login(email, password, check_connection=check_connection)
         self._cancel_pending_auto_login()
-        await self.events.publish(CloudEvent(type=CloudEventType.LOGIN))
+        await self.events.publish(LoginEvent(auto=auto))
 
     async def login_verify_totp(
         self,
@@ -459,7 +468,7 @@ class Cloud(Generic[_ClientT]):
             email, code, mfa_tokens, check_connection=check_connection
         )
         self._cancel_pending_auto_login()
-        await self.events.publish(CloudEvent(type=CloudEventType.LOGIN))
+        await self.events.publish(LoginEvent(auto=False))
 
     def _cancel_pending_auto_login(self) -> None:
         """Cancel a pending auto-login, guarded to never cancel the running task."""
@@ -468,9 +477,9 @@ class Cloud(Generic[_ClientT]):
             task.cancel()
             self._auto_login_task = None
 
-    async def _publish_auto_login_failed(self) -> None:
+    async def _publish_auto_login_failed(self, reason: str) -> None:
         """Notify subscribers that auto login gave up without logging in."""
-        await self.events.publish(CloudEvent(type=CloudEventType.AUTO_LOGIN_FAILED))
+        await self.events.publish(LoginFailedEvent(auto=True, reason=reason))
 
     async def register_and_auto_login(
         self,
@@ -484,10 +493,10 @@ class Cloud(Generic[_ClientT]):
         Returns an AutoLoginController with cancel(), attempt_now() (forces an immediate
         retry) and resend() (resends the confirmation email and restarts the schedule);
         a background task retries login with backoff until confirmed, else gives up
-        after ~a day. On success a LOGIN event is published. If the task gives up
-        without logging in (schedule exhausted, a fatal CloudError, or an unexpected
-        exception), an AUTO_LOGIN_FAILED event is published so the caller can stop
-        waiting.
+        after ~a day. On success a LOGIN event is published (with auto=True). If the
+        task gives up without logging in (schedule exhausted, a fatal CloudError, or
+        an unexpected exception), a LOGIN_FAILED event is published (with auto=True and
+        a reason) so the caller can stop waiting.
         """
         # Normalize email, so the auto-login uses the same value as the registration
         email = email.lower()
@@ -547,7 +556,7 @@ class Cloud(Generic[_ClientT]):
                     backoff = min(backoff * 2, AUTO_LOGIN_MAX_TOTAL_BACKOFF)
 
                 try:
-                    await self.login(email, password)
+                    await self.login(email, password, auto=True)
                 except UserNotConfirmed:
                     _LOGGER.debug(
                         "Account not confirmed yet, retrying auto login in %s",
@@ -576,7 +585,9 @@ class Cloud(Generic[_ClientT]):
                         "Giving up auto login, account was not confirmed within %s",
                         seconds_as_dhms(AUTO_LOGIN_MAX_TOTAL_BACKOFF),
                     )
-                    await self._publish_auto_login_failed()
+                    await self._publish_auto_login_failed(
+                        "Account was not confirmed in time"
+                    )
                     return
 
                 if await wait_for_event(wake, backoff):
@@ -589,11 +600,15 @@ class Cloud(Generic[_ClientT]):
             raise
         except CloudError as err:
             _LOGGER.warning("Auto login stopped: %s", err)
-            await self._publish_auto_login_failed()
+            await self._publish_auto_login_failed(
+                "A cloud error occurred while logging in"
+            )
         except Exception:  # pylint: disable=broad-except
             # Safety net, so an unexpected error never escapes this background task
             _LOGGER.exception("Unexpected error in auto login")
-            await self._publish_auto_login_failed()
+            await self._publish_auto_login_failed(
+                "An unexpected error occurred while logging in"
+            )
         finally:
             if self._auto_login_task is asyncio.current_task():
                 self._auto_login_task = None

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -468,6 +468,10 @@ class Cloud(Generic[_ClientT]):
             task.cancel()
             self._auto_login_task = None
 
+    async def _publish_auto_login_failed(self) -> None:
+        """Notify subscribers that auto login gave up without logging in."""
+        await self.events.publish(CloudEvent(type=CloudEventType.AUTO_LOGIN_FAILED))
+
     async def register_and_auto_login(
         self,
         email: str,
@@ -480,7 +484,9 @@ class Cloud(Generic[_ClientT]):
         Returns an AutoLoginController with cancel(), attempt_now() (forces an immediate
         retry) and resend() (resends the confirmation email and restarts the schedule);
         a background task retries login with backoff until confirmed, else gives up
-        after ~a day.
+        after ~a day. On success a LOGIN event is published; if the task gives up
+        without logging in (schedule exhausted or a fatal error) an AUTO_LOGIN_FAILED
+        event is published so the caller can stop waiting.
         """
         # Normalize email, so the auto-login uses the same value as the registration
         email = email.lower()
@@ -569,6 +575,7 @@ class Cloud(Generic[_ClientT]):
                         "Giving up auto login, account was not confirmed within %s",
                         seconds_as_dhms(AUTO_LOGIN_MAX_TOTAL_BACKOFF),
                     )
+                    await self._publish_auto_login_failed()
                     return
 
                 if await wait_for_event(wake, backoff):
@@ -581,9 +588,11 @@ class Cloud(Generic[_ClientT]):
             raise
         except CloudError as err:
             _LOGGER.warning("Auto login stopped: %s", err)
+            await self._publish_auto_login_failed()
         except Exception:  # pylint: disable=broad-except
             # Safety net, so an unexpected error never escapes this background task
             _LOGGER.exception("Unexpected error in auto login")
+            await self._publish_auto_login_failed()
         finally:
             if self._auto_login_task is asyncio.current_task():
                 self._auto_login_task = None

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -75,6 +75,7 @@ from .events import (
     CloudhookDeletedEvent,
     LoginEvent,
     LoginFailedEvent,
+    LoginFailedReason,
 )
 from .exceptions import (
     CloudError,
@@ -161,6 +162,7 @@ __all__ = [
     "InvalidTotpCode",
     "LoginEvent",
     "LoginFailedEvent",
+    "LoginFailedReason",
     "MFARequired",
     "MigratePaypalAgreementInfo",
     "NabuCasaAuthenticationError",
@@ -477,7 +479,7 @@ class Cloud(Generic[_ClientT]):
             task.cancel()
             self._auto_login_task = None
 
-    async def _publish_auto_login_failed(self, reason: str) -> None:
+    async def _publish_auto_login_failed(self, reason: LoginFailedReason) -> None:
         """Notify subscribers that auto login gave up without logging in."""
         await self.events.publish(LoginFailedEvent(auto=True, reason=reason))
 
@@ -585,9 +587,7 @@ class Cloud(Generic[_ClientT]):
                         "Giving up auto login, account was not confirmed within %s",
                         seconds_as_dhms(AUTO_LOGIN_MAX_TOTAL_BACKOFF),
                     )
-                    await self._publish_auto_login_failed(
-                        "Account was not confirmed in time"
-                    )
+                    await self._publish_auto_login_failed(LoginFailedReason.TIMEOUT)
                     return
 
                 if await wait_for_event(wake, backoff):
@@ -600,15 +600,11 @@ class Cloud(Generic[_ClientT]):
             raise
         except CloudError as err:
             _LOGGER.warning("Auto login stopped: %s", err)
-            await self._publish_auto_login_failed(
-                "A cloud error occurred while logging in"
-            )
+            await self._publish_auto_login_failed(LoginFailedReason.CLOUD_ERROR)
         except Exception:  # pylint: disable=broad-except
             # Safety net, so an unexpected error never escapes this background task
             _LOGGER.exception("Unexpected error in auto login")
-            await self._publish_auto_login_failed(
-                "An unexpected error occurred while logging in"
-            )
+            await self._publish_auto_login_failed(LoginFailedReason.UNEXPECTED_ERROR)
         finally:
             if self._auto_login_task is asyncio.current_task():
                 self._auto_login_task = None

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -470,7 +470,7 @@ class Cloud(Generic[_ClientT]):
             email, code, mfa_tokens, check_connection=check_connection
         )
         self._cancel_pending_auto_login()
-        await self.events.publish(LoginEvent(auto=False))
+        await self.events.publish(LoginEvent())
 
     def _cancel_pending_auto_login(self) -> None:
         """Cancel a pending auto-login, guarded to never cancel the running task."""

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -484,9 +484,9 @@ class Cloud(Generic[_ClientT]):
         Returns an AutoLoginController with cancel(), attempt_now() (forces an immediate
         retry) and resend() (resends the confirmation email and restarts the schedule);
         a background task retries login with backoff until confirmed, else gives up
-        after ~a day. On success a LOGIN event is published; if the task gives up
-        without logging in (schedule exhausted or a fatal error) an AUTO_LOGIN_FAILED
-        event is published so the caller can stop waiting.
+        after ~a day. On success a LOGIN event is published. If the task gives up
+        without logging in (schedule exhausted, a fatal CloudError, or an unexpected
+        exception), an AUTO_LOGIN_FAILED event is published so the caller can stop waiting.
         """
         # Normalize email, so the auto-login uses the same value as the registration
         email = email.lower()

--- a/hass_nabucasa/events/__init__.py
+++ b/hass_nabucasa/events/__init__.py
@@ -8,6 +8,7 @@ from .types import (
     CloudhookDeletedEvent,
     LoginEvent,
     LoginFailedEvent,
+    LoginFailedReason,
 )
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "EventBusError",
     "LoginEvent",
     "LoginFailedEvent",
+    "LoginFailedReason",
 ]

--- a/hass_nabucasa/events/__init__.py
+++ b/hass_nabucasa/events/__init__.py
@@ -6,6 +6,8 @@ from .types import (
     CloudEventType,
     CloudhookCreatedEvent,
     CloudhookDeletedEvent,
+    LoginEvent,
+    LoginFailedEvent,
 )
 
 __all__ = [
@@ -15,4 +17,6 @@ __all__ = [
     "CloudhookCreatedEvent",
     "CloudhookDeletedEvent",
     "EventBusError",
+    "LoginEvent",
+    "LoginFailedEvent",
 ]

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -85,5 +85,5 @@ class LoginFailedEvent(CloudEvent):
     """Login failed event."""
 
     type: CloudEventType = field(default=CloudEventType.LOGIN_FAILED, init=False)
-    auto: bool = False
     reason: str
+    auto: bool = False

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -21,6 +21,7 @@ def _timestamp_factory() -> float:
 class CloudEventType(StrEnum):
     """Cloud event types."""
 
+    AUTO_LOGIN_FAILED = "auto_login_failed"
     CLOUDHOOK_CREATED = "cloudhook_created"
     CLOUDHOOK_DELETED = "cloudhook_deleted"
     LOGIN = "login"

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -72,6 +72,14 @@ class CloudhookDeletedEvent(CloudEvent):
     cloudhook: CloudhookDetails
 
 
+class LoginFailedReason(StrEnum):
+    """Reason the register-and-auto-login flow gave up without logging in."""
+
+    TIMEOUT = "timeout"
+    CLOUD_ERROR = "cloud_error"
+    UNEXPECTED_ERROR = "unexpected_error"
+
+
 @dataclass(kw_only=True, frozen=True)
 class LoginEvent(CloudEvent):
     """Login succeeded event."""
@@ -85,5 +93,5 @@ class LoginFailedEvent(CloudEvent):
     """Login failed event."""
 
     type: CloudEventType = field(default=CloudEventType.LOGIN_FAILED, init=False)
-    reason: str
+    reason: LoginFailedReason
     auto: bool = False

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -21,10 +21,10 @@ def _timestamp_factory() -> float:
 class CloudEventType(StrEnum):
     """Cloud event types."""
 
-    AUTO_LOGIN_FAILED = "auto_login_failed"
     CLOUDHOOK_CREATED = "cloudhook_created"
     CLOUDHOOK_DELETED = "cloudhook_deleted"
     LOGIN = "login"
+    LOGIN_FAILED = "login_failed"
     LOGOUT = "logout"
     RELAYER_CONNECTED = "relayer_connected"
     RELAYER_DISCONNECTED = "relayer_disconnected"
@@ -70,3 +70,20 @@ class CloudhookDeletedEvent(CloudEvent):
 
     type: CloudEventType = field(default=CloudEventType.CLOUDHOOK_DELETED, init=False)
     cloudhook: CloudhookDetails
+
+
+@dataclass(kw_only=True, frozen=True)
+class LoginEvent(CloudEvent):
+    """Login succeeded event."""
+
+    type: CloudEventType = field(default=CloudEventType.LOGIN, init=False)
+    auto: bool = False
+
+
+@dataclass(kw_only=True, frozen=True)
+class LoginFailedEvent(CloudEvent):
+    """Login failed event."""
+
+    type: CloudEventType = field(default=CloudEventType.LOGIN_FAILED, init=False)
+    auto: bool = False
+    reason: str

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -878,10 +878,13 @@ async def test_register_and_auto_login_publishes_login_event(cl: cloud.Cloud):
 
     received: list[cloud.CloudEvent] = []
 
-    async def on_login(event: cloud.CloudEvent) -> None:
+    async def on_event(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN, handler=on_login)
+    cl.events.subscribe(
+        event_type=[cloud.CloudEventType.LOGIN, cloud.CloudEventType.AUTO_LOGIN_FAILED],
+        handler=on_event,
+    )
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
         await cl.register_and_auto_login("email@home-assistant.io", "password")
@@ -892,6 +895,154 @@ async def test_register_and_auto_login_publishes_login_event(cl: cloud.Cloud):
     assert cl.auth.async_login.call_count == 2
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN
+    assert cl._auto_login_task is None
+
+
+async def test_register_and_auto_login_publishes_failed_event_on_give_up(
+    cl: cloud.Cloud,
+):
+    """Test giving up after the schedule is exhausted emits AUTO_LOGIN_FAILED."""
+    cl.auth.async_register = AsyncMock()
+    cl.login = AsyncMock(side_effect=cloud.UserNotConfirmed())
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_failed(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(
+        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
+    )
+
+    with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
+        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        task = cl._auto_login_task
+        assert task is not None
+        await task
+
+    assert len(received) == 1
+    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert cl._auto_login_task is None
+
+
+async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
+    cl: cloud.Cloud,
+):
+    """Test a fatal error emits AUTO_LOGIN_FAILED so the caller stops waiting."""
+    cl.auth.async_register = AsyncMock()
+    cl.login = AsyncMock(side_effect=cloud.Unauthenticated("nope"))
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_failed(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(
+        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
+    )
+
+    with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
+        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        task = cl._auto_login_task
+        assert task is not None
+        await task
+
+    assert cl.login.call_count == 1
+    assert len(received) == 1
+    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert cl._auto_login_task is None
+
+
+async def test_register_and_auto_login_publishes_failed_event_on_unexpected_error(
+    cl: cloud.Cloud,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test an unexpected error emits AUTO_LOGIN_FAILED without escaping the task."""
+    cl.auth.async_register = AsyncMock()
+    cl.login = AsyncMock(side_effect=RuntimeError("boom"))
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_failed(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(
+        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
+    )
+
+    with (
+        caplog.at_level(logging.ERROR),
+        patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)),
+    ):
+        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        task = cl._auto_login_task
+        assert task is not None
+        await task
+
+    assert "Unexpected error in auto login" in caplog.text
+    assert len(received) == 1
+    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert cl._auto_login_task is None
+
+
+async def test_register_and_auto_login_no_failed_event_on_cancel(cl: cloud.Cloud):
+    """Test a cancelled auto login does not emit AUTO_LOGIN_FAILED."""
+    cl.auth.async_register = AsyncMock()
+    started = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def blocking_login(*args, **kwargs):
+        """Park in the first login attempt until cancelled."""
+        started.set()
+        await parked.wait()
+
+    cl.login = AsyncMock(side_effect=blocking_login)
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_failed(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(
+        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
+    )
+
+    controller = await cl.register_and_auto_login("email@home-assistant.io", "password")
+    task = cl._auto_login_task
+    assert task is not None
+
+    await started.wait()
+    controller.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert received == []
+    assert cl._auto_login_task is None
+
+
+async def test_register_and_auto_login_no_failed_event_on_login_race(cl: cloud.Cloud):
+    """Test a login winning the race does not emit AUTO_LOGIN_FAILED."""
+    cl.auth.async_register = AsyncMock()
+    cl.login = AsyncMock(side_effect=cloud.AlreadyLoggedIn("already logged in"))
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_failed(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(
+        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
+    )
+
+    with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
+        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        task = cl._auto_login_task
+        assert task is not None
+        await task
+
+    assert cl.login.call_count == 1
+    assert received == []
     assert cl._auto_login_task is None
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -940,7 +940,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_give_up(
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
-    assert received[0].reason == "Account was not confirmed in time"
+    assert received[0].reason is cloud.LoginFailedReason.TIMEOUT
     assert cl._auto_login_task is None
 
 
@@ -968,7 +968,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
-    assert received[0].reason == "A cloud error occurred while logging in"
+    assert received[0].reason is cloud.LoginFailedReason.CLOUD_ERROR
     assert cl._auto_login_task is None
 
 
@@ -1000,7 +1000,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
-    assert received[0].reason == "An unexpected error occurred while logging in"
+    assert received[0].reason is cloud.LoginFailedReason.UNEXPECTED_ERROR
     assert cl._auto_login_task is None
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -574,7 +574,7 @@ async def test_register_and_auto_login_logs_in_after_confirmation(cl: cloud.Clou
         "email@home-assistant.io", "password", client_metadata={"test": "metadata"}
     )
     assert cl.login.call_count == 2
-    cl.login.assert_called_with("email@home-assistant.io", "password")
+    cl.login.assert_called_with("email@home-assistant.io", "password", auto=True)
     assert wait_mock.call_count == 1
     assert cl._auto_login_task is None
 
@@ -868,7 +868,7 @@ async def test_register_and_auto_login_normalizes_email(cl: cloud.Cloud):
     cl.auth.async_register.assert_awaited_once_with(
         "user@example.com", "password", client_metadata=None
     )
-    cl.login.assert_called_with("user@example.com", "password")
+    cl.login.assert_called_with("user@example.com", "password", auto=True)
 
 
 async def test_register_and_auto_login_publishes_login_event(cl: cloud.Cloud):
@@ -882,7 +882,7 @@ async def test_register_and_auto_login_publishes_login_event(cl: cloud.Cloud):
         received.append(event)
 
     cl.events.subscribe(
-        event_type=[cloud.CloudEventType.LOGIN, cloud.CloudEventType.AUTO_LOGIN_FAILED],
+        event_type=[cloud.CloudEventType.LOGIN, cloud.CloudEventType.LOGIN_FAILED],
         handler=on_event,
     )
 
@@ -895,13 +895,32 @@ async def test_register_and_auto_login_publishes_login_event(cl: cloud.Cloud):
     assert cl.auth.async_login.call_count == 2
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN
+    assert received[0].auto is True
     assert cl._auto_login_task is None
+
+
+async def test_login_publishes_login_event_not_auto(cl: cloud.Cloud):
+    """Test a manual login emits a LOGIN event flagged as not auto."""
+    cl.auth.async_login = AsyncMock()
+
+    received: list[cloud.CloudEvent] = []
+
+    async def on_event(event: cloud.CloudEvent) -> None:
+        received.append(event)
+
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN, handler=on_event)
+
+    await cl.login("email@home-assistant.io", "password")
+
+    assert len(received) == 1
+    assert received[0].type is cloud.CloudEventType.LOGIN
+    assert received[0].auto is False
 
 
 async def test_register_and_auto_login_publishes_failed_event_on_give_up(
     cl: cloud.Cloud,
 ):
-    """Test giving up after the schedule is exhausted emits AUTO_LOGIN_FAILED."""
+    """Test giving up after the schedule is exhausted emits LOGIN_FAILED."""
     cl.auth.async_register = AsyncMock()
     cl.login = AsyncMock(side_effect=cloud.UserNotConfirmed())
 
@@ -910,9 +929,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_give_up(
     async def on_failed(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(
-        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
-    )
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
         await cl.register_and_auto_login("email@home-assistant.io", "password")
@@ -921,14 +938,16 @@ async def test_register_and_auto_login_publishes_failed_event_on_give_up(
         await task
 
     assert len(received) == 1
-    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
+    assert received[0].auto is True
+    assert received[0].reason == "Account was not confirmed in time"
     assert cl._auto_login_task is None
 
 
 async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     cl: cloud.Cloud,
 ):
-    """Test a fatal error emits AUTO_LOGIN_FAILED so the caller stops waiting."""
+    """Test a fatal error emits LOGIN_FAILED so the caller stops waiting."""
     cl.auth.async_register = AsyncMock()
     cl.login = AsyncMock(side_effect=cloud.Unauthenticated("nope"))
 
@@ -937,9 +956,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     async def on_failed(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(
-        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
-    )
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
         await cl.register_and_auto_login("email@home-assistant.io", "password")
@@ -949,7 +966,9 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
 
     assert cl.login.call_count == 1
     assert len(received) == 1
-    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
+    assert received[0].auto is True
+    assert received[0].reason == "A cloud error occurred while logging in"
     assert cl._auto_login_task is None
 
 
@@ -957,7 +976,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
     cl: cloud.Cloud,
     caplog: pytest.LogCaptureFixture,
 ):
-    """Test an unexpected error emits AUTO_LOGIN_FAILED without escaping the task."""
+    """Test an unexpected error emits LOGIN_FAILED without escaping the task."""
     cl.auth.async_register = AsyncMock()
     cl.login = AsyncMock(side_effect=RuntimeError("boom"))
 
@@ -966,9 +985,7 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
     async def on_failed(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(
-        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
-    )
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with (
         caplog.at_level(logging.ERROR),
@@ -981,12 +998,14 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
 
     assert "Unexpected error in auto login" in caplog.text
     assert len(received) == 1
-    assert received[0].type is cloud.CloudEventType.AUTO_LOGIN_FAILED
+    assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
+    assert received[0].auto is True
+    assert received[0].reason == "An unexpected error occurred while logging in"
     assert cl._auto_login_task is None
 
 
 async def test_register_and_auto_login_no_failed_event_on_cancel(cl: cloud.Cloud):
-    """Test a cancelled auto login does not emit AUTO_LOGIN_FAILED."""
+    """Test a cancelled auto login does not emit LOGIN_FAILED."""
     cl.auth.async_register = AsyncMock()
     started = asyncio.Event()
     parked = asyncio.Event()
@@ -1003,9 +1022,7 @@ async def test_register_and_auto_login_no_failed_event_on_cancel(cl: cloud.Cloud
     async def on_failed(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(
-        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
-    )
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     controller = await cl.register_and_auto_login("email@home-assistant.io", "password")
     task = cl._auto_login_task
@@ -1022,7 +1039,7 @@ async def test_register_and_auto_login_no_failed_event_on_cancel(cl: cloud.Cloud
 
 
 async def test_register_and_auto_login_no_failed_event_on_login_race(cl: cloud.Cloud):
-    """Test a login winning the race does not emit AUTO_LOGIN_FAILED."""
+    """Test a login winning the race does not emit LOGIN_FAILED."""
     cl.auth.async_register = AsyncMock()
     cl.login = AsyncMock(side_effect=cloud.AlreadyLoggedIn("already logged in"))
 
@@ -1031,9 +1048,7 @@ async def test_register_and_auto_login_no_failed_event_on_login_race(cl: cloud.C
     async def on_failed(event: cloud.CloudEvent) -> None:
         received.append(event)
 
-    cl.events.subscribe(
-        event_type=cloud.CloudEventType.AUTO_LOGIN_FAILED, handler=on_failed
-    )
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
         await cl.register_and_auto_login("email@home-assistant.io", "password")


### PR DESCRIPTION
## Summary

Give Home Assistant structured context on the outcome of a login by publishing typed login events:

- The `LOGIN` event is now a typed `LoginEvent` carrying `auto: bool`. `Cloud.login()` gains a keyword-only `auto` (default `False`); the `register_and_auto_login` background task passes `auto=True`, while user-initiated logins and TOTP verification stay `False`. This lets HA tell an automatic login apart from a manual one.
- A new `LOGIN_FAILED` event (`LoginFailedEvent`) is published when the `register_and_auto_login` background task gives up **without** logging in. It carries `auto: bool` (currently always `True`, as only the auto-login flow emits it) and a typed `reason` (`LoginFailedReason`):
  - `TIMEOUT` — retry schedule exhausted (~1 day)
  - `CLOUD_ERROR` — a fatal `CloudError`
  - `UNEXPECTED_ERROR` — the unexpected-error safety net
- `LOGIN_FAILED` is **not** fired on user cancellation (the caller already knows) or the `AlreadyLoggedIn` race (a `LOGIN` event was already published).

Previously the only login event was an untyped `LOGIN` with no payload, so HA could neither distinguish an automatic login from a manual one nor learn that (or why) an auto-login had stopped — leaving it waiting indefinitely.

## Test plan
- `LOGIN` carries `auto=True` on auto-login success and `auto=False` on a manual login
- `LOGIN_FAILED` carries `auto=True` and the expected `LoginFailedReason` for give-up, fatal error, and unexpected error; not fired on cancellation or the login race
- `scripts/test`: 512 passed
- `ruff check`, `ruff format --check`, and `mypy hass_nabucasa`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
