### PR TITLE
Support lazy loading of service discovery data in API calls

### DIFF
--- a/hass_nabucasa/api.py
+++ b/hass_nabucasa/api.py
@@ -280,7 +280,7 @@ class ApiBase:
             assert self._cloud.id_token is not None
 
         if action is not None:
-            final_url = self._cloud.service_discovery.action_url(
+            final_url = await self._cloud.service_discovery.async_action_url(
                 action=action,
                 **(action_values or {}),
             )

--- a/tests/common.py
+++ b/tests/common.py
@@ -18,6 +18,11 @@ import pytest
 from snitun.client.access_list import AccessList
 
 from hass_nabucasa.client import CloudClient
+from hass_nabucasa.service_discovery import (
+    ServiceDiscoveryCacheData,
+    ServiceDiscoveryResponse,
+)
+from hass_nabucasa.utils import utcnow
 
 FROZEN_NOW_AS_TIMESTAMP = 1537185600  # 2018-09-17 12:00:00 UTC
 
@@ -41,6 +46,18 @@ def construct_service_discovery_actions(
         **fixture_data["actions"],
         **(overrides or {}),
     }
+
+
+def prefilled_service_discovery_cache() -> ServiceDiscoveryCacheData:
+    """Return a valid service discovery cache holding no actions.
+
+    Action URLs then resolve through the fallback actions, without any request
+    being made to the well-known endpoint.
+    """
+    return ServiceDiscoveryCacheData(
+        data=ServiceDiscoveryResponse(actions={}, valid_for=3600, version="test"),
+        valid_until=utcnow().timestamp() + 3600,
+    )
 
 
 class MockClient(CloudClient):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,12 @@ import pytest
 
 import hass_nabucasa
 
-from .common import WELL_KNOWN_SERVICE_DISCOVERY_JSON, FreezeTimeFixture, MockClient
+from .common import (
+    WELL_KNOWN_SERVICE_DISCOVERY_JSON,
+    FreezeTimeFixture,
+    MockClient,
+    prefilled_service_discovery_cache,
+)
 from .utils.aiohttp import AiohttpClientMocker, mock_aiohttp_client
 
 logging.basicConfig(level=logging.DEBUG)
@@ -118,11 +123,23 @@ def cloud_client(cloud_mock: MagicMock) -> MockClient:
     return cast("MockClient", cloud_mock.client)
 
 
+@pytest.fixture(name="prefill_service_discovery_cache")
+def prefill_service_discovery_cache_fixture() -> bool:
+    """Return if the cloud fixture starts with a valid service discovery cache.
+
+    The cache is prefilled without any actions, so action URLs still resolve via
+    the fallback actions while no request is made to the well-known endpoint.
+    Override this fixture with False to start without a cache.
+    """
+    return True
+
+
 @pytest.fixture
 async def cloud(
     aioclient_mock: AiohttpClientMocker,
     loop: asyncio.AbstractEventLoop,
     tmp_path: Path,
+    prefill_service_discovery_cache: bool,
 ) -> AsyncGenerator[hass_nabucasa.Cloud, Any]:
     """Create a cloud fixture."""
     client_session = aioclient_mock.create_session(loop)
@@ -195,6 +212,9 @@ async def cloud(
         cloud.id_token = id_token
         cloud.access_token = access_token
         cloud.refresh_token = refresh_token
+
+        if prefill_service_discovery_cache:
+            cloud.service_discovery._memory_cache = prefilled_service_discovery_cache()
 
         yield cloud
         await client_session.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
+from aiohttp import ClientError
 import pytest
 import voluptuous as vol
 
@@ -603,6 +604,67 @@ async def test_call_cloud_api_with_action_values(
         )
 
         assert result == {"result": "success"}
+
+
+async def test_call_cloud_api_with_action_loads_service_discovery(
+    aioclient_mock: AiohttpClientMocker,
+    cloud: Cloud,
+) -> None:
+    """Test _call_cloud_api with an action loads missing service discovery data."""
+    test_api = AwesomeApiClass(cloud)
+    cloud.service_discovery._memory_cache = None
+
+    aioclient_mock.get(
+        f"https://{cloud.api_server}/.well-known/service-discovery",
+        json={
+            "actions": {"test_api_action": "https://example.com/test/{param}/action"},
+            "valid_for": 3600,
+            "version": "1.0",
+        },
+    )
+    aioclient_mock.get(
+        "https://example.com/test/value/action",
+        json={"result": "success"},
+    )
+
+    result = await test_api._call_cloud_api(
+        action="test_api_action",
+        action_values={"param": "value"},
+    )
+
+    assert result == {"result": "success"}
+    assert cloud.service_discovery._memory_cache is not None
+    assert cloud.service_discovery._memory_cache["data"]["version"] == "1.0"
+    assert [str(url) for _, url, _, _ in aioclient_mock.mock_calls] == [
+        f"https://{cloud.api_server}/.well-known/service-discovery",
+        "https://example.com/test/value/action",
+    ]
+
+
+async def test_call_cloud_api_with_action_when_service_discovery_fails(
+    aioclient_mock: AiohttpClientMocker,
+    cloud: Cloud,
+) -> None:
+    """Test _call_cloud_api with an action when service discovery is unavailable."""
+    test_api = AwesomeApiClass(cloud)
+    cloud.service_discovery._memory_cache = None
+
+    aioclient_mock.get(
+        f"https://{cloud.api_server}/.well-known/service-discovery",
+        exc=ClientError("boom!"),
+    )
+    aioclient_mock.get(
+        "https://example.com/test/value/action",
+        json={"result": "success"},
+    )
+
+    result = await test_api._call_cloud_api(
+        action="test_api_action",
+        action_values={"param": "value"},
+    )
+
+    assert result == {"result": "success"}
+    assert cloud.service_discovery._memory_cache is None
 
 
 async def test_hostname_property_default(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,7 +20,7 @@ from hass_nabucasa.const import (
 )
 from hass_nabucasa.utils import utcnow
 
-from .common import MockClient
+from .common import MockClient, prefilled_service_discovery_cache
 
 
 @pytest.fixture(autouse=True)
@@ -49,11 +49,13 @@ async def cl(cloud_client) -> cloud.Cloud:
         "hass_nabucasa.service_discovery.ServiceDiscovery.async_start_service_discovery",
         new=AsyncMock(),
     ):
-        yield cloud.Cloud(
+        instance = cloud.Cloud(
             cloud_client,
             cloud.MODE_DEV,
             api_server="example.com",
         )
+        instance.service_discovery._memory_cache = prefilled_service_discovery_cache()
+        yield instance
 
 
 def test_constructor_loads_info_from_constant(cloud_client):

--- a/tests/test_service_discovery.py
+++ b/tests/test_service_discovery.py
@@ -47,6 +47,12 @@ def assert_snapshot_with_logs(
     assert {"result": result, "log": extract_log_messages(caplog)} == snapshot
 
 
+@pytest.fixture(name="prefill_service_discovery_cache")
+def prefill_service_discovery_cache_fixture() -> bool:
+    """Start without a service discovery cache, these tests populate it."""
+    return False
+
+
 @pytest.fixture(autouse=True)
 def jitter_patch() -> Generator[Any, Any, Any]:
     """Mock jitter to always return 0."""


### PR DESCRIPTION
## Summary
This change adds support for lazy loading service discovery data when making cloud API calls with actions. Previously, the code assumed service discovery data was already cached; now it will automatically fetch it if needed, with graceful fallback if the fetch fails.

## Key Changes

- **API call enhancement**: Modified `_call_cloud_api()` in `hass_nabucasa/api.py` to use `async_action_url()` instead of `action_url()`, enabling async service discovery data loading
- **Test coverage**: Added two new test cases:
  - `test_call_cloud_api_with_action_loads_service_discovery`: Verifies that missing service discovery data is fetched and cached during an API call
  - `test_call_cloud_api_with_action_when_service_discovery_fails`: Verifies graceful handling when service discovery is unavailable
- **Test infrastructure**: 
  - Added `prefilled_service_discovery_cache()` helper function to create valid cache entries for tests
  - Added `prefill_service_discovery_cache` fixture to control whether tests start with a pre-populated cache
  - Updated `conftest.py` to use the new fixture, allowing tests to opt-out of cache prefilling
  - Updated `test_service_discovery.py` to disable cache prefilling for its tests
  - Updated `test_init.py` to manually populate the cache for its cloud instance

## Implementation Details

- The `async_action_url()` method handles fetching service discovery data if the cache is empty, then falls back to action URL resolution
- Service discovery failures are caught and logged, allowing API calls to proceed (likely using fallback mechanisms)
- Tests verify both the happy path (successful discovery load and cache) and error path (discovery unavailable but API call still succeeds)
- The fixture-based approach allows fine-grained control over cache state per test, improving test isolation

https://claude.ai/code/session_01Djft4Luik9Y7QrickQGXqU