### PR TITLE
Support synchronous event bus handlers

### DIFF
--- a/hass_nabucasa/events/bus.py
+++ b/hass_nabucasa/events/bus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 import contextlib
+import inspect
 import logging
 
 from ..exceptions import CloudError
@@ -24,14 +25,14 @@ class CloudEventBus:
         """Initialize the event bus."""
         self._subscribers: dict[
             str,
-            list[Callable[[CloudEvent], Awaitable[None]]],
+            list[Callable[[CloudEvent], Awaitable[None] | None]],
         ] = {k.value: [] for k in CloudEventType}
 
     def subscribe(
         self,
         *,
         event_type: CloudEventType | list[CloudEventType],
-        handler: Callable[[CloudEvent], Awaitable[None]],
+        handler: Callable[[CloudEvent], Awaitable[None] | None],
     ) -> Callable[[], None]:
         """Subscribe to an event type or list of event types."""
         event_types = event_type if isinstance(event_type, list) else [event_type]
@@ -70,8 +71,16 @@ class CloudEventBus:
 
         _LOGGER.debug("Publish %s to %d subscribers", event_type, len(handlers))
 
+        async def _invoke(
+            handler: Callable[[CloudEvent], Awaitable[None] | None],
+        ) -> None:
+            """Invoke a handler, awaiting it only when it returns an awaitable."""
+            result = handler(event)
+            if inspect.isawaitable(result):
+                await result
+
         results = await asyncio.gather(
-            *[handler(event) for handler in handlers],
+            *[_invoke(handler) for handler in handlers],
             return_exceptions=True,
         )
 

--- a/tests/events/__snapshots__/test_bus.ambr
+++ b/tests/events/__snapshots__/test_bus.ambr
@@ -29,6 +29,12 @@
   [DEBUG] hass_nabucasa.events.bus: Publish relayer_connected to 3 subscribers
   '''
 # ---
+# name: test_publish_to_sync_handler
+  '''
+  [DEBUG] hass_nabucasa.events.bus: sync_handler subscribed to [<CloudEventType.RELAYER_CONNECTED: 'relayer_connected'>]
+  [DEBUG] hass_nabucasa.events.bus: Publish relayer_connected to 1 subscribers
+  '''
+# ---
 # name: test_publish_without_data
   '''
   [DEBUG] hass_nabucasa.events.bus: AsyncMock subscribed to [<CloudEventType.RELAYER_CONNECTED: 'relayer_connected'>]

--- a/tests/events/__snapshots__/test_bus.ambr
+++ b/tests/events/__snapshots__/test_bus.ambr
@@ -7,6 +7,14 @@
   [ERROR] hass_nabucasa.events.bus: Error in event handler AsyncMock for event relayer_connected
   '''
 # ---
+# name: test_error_handling_sync_handler
+  '''
+  [DEBUG] hass_nabucasa.events.bus: failing_sync_handler subscribed to [<CloudEventType.RELAYER_CONNECTED: 'relayer_connected'>]
+  [DEBUG] hass_nabucasa.events.bus: working_sync_handler subscribed to [<CloudEventType.RELAYER_CONNECTED: 'relayer_connected'>]
+  [DEBUG] hass_nabucasa.events.bus: Publish relayer_connected to 2 subscribers
+  [ERROR] hass_nabucasa.events.bus: Error in event handler failing_sync_handler for event relayer_connected
+  '''
+# ---
 # name: test_event_timestamp
   '''
   [DEBUG] hass_nabucasa.events.bus: AsyncMock subscribed to [<CloudEventType.RELAYER_CONNECTED: 'relayer_connected'>]

--- a/tests/events/test_bus.py
+++ b/tests/events/test_bus.py
@@ -136,6 +136,35 @@ async def test_error_handling(
     assert extract_log_messages(caplog) == snapshot
 
 
+async def test_error_handling_sync_handler(
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+):
+    """Test that a raising synchronous handler is isolated and logged."""
+    calls: list[str] = []
+
+    def failing_sync_handler(event: CloudEvent) -> None:
+        calls.append("failing")
+        raise ValueError("Test error")
+
+    def working_sync_handler(event: CloudEvent) -> None:
+        calls.append("working")
+
+    event_bus = CloudEventBus()
+
+    event_bus.subscribe(
+        event_type=CloudEventType.RELAYER_CONNECTED, handler=failing_sync_handler
+    )
+    event_bus.subscribe(
+        event_type=CloudEventType.RELAYER_CONNECTED, handler=working_sync_handler
+    )
+
+    await event_bus.publish(event=RelayerConnectedEvent())
+
+    assert sorted(calls) == ["failing", "working"]
+    assert extract_log_messages(caplog) == snapshot
+
+
 async def test_multiple_event_types(
     caplog: pytest.LogCaptureFixture,
     snapshot: SnapshotAssertion,

--- a/tests/events/test_bus.py
+++ b/tests/events/test_bus.py
@@ -8,6 +8,7 @@ from syrupy import SnapshotAssertion
 from hass_nabucasa.events import CloudEventBus
 from hass_nabucasa.events.bus import EventBusError
 from hass_nabucasa.events.types import (
+    CloudEvent,
     CloudEventType,
     RelayerConnectedEvent,
     RelayerDisconnectedEvent,
@@ -234,6 +235,28 @@ async def test_subscribe_to_multiple_event_types(
     await event_bus.publish(event=RelayerConnectedEvent())
     assert len(subscriber.call_args_list) == 2
 
+    assert extract_log_messages(caplog) == snapshot
+
+
+async def test_publish_to_sync_handler(
+    caplog: pytest.LogCaptureFixture,
+    snapshot: SnapshotAssertion,
+):
+    """Test a plain (non-async) handler is invoked and its None return is fine."""
+    received: list[CloudEvent] = []
+
+    def sync_handler(event: CloudEvent) -> None:
+        received.append(event)
+
+    event_bus = CloudEventBus()
+    event_bus.subscribe(
+        event_type=CloudEventType.RELAYER_CONNECTED, handler=sync_handler
+    )
+
+    await event_bus.publish(event=RelayerConnectedEvent())
+
+    assert len(received) == 1
+    assert received[0].type == CloudEventType.RELAYER_CONNECTED
     assert extract_log_messages(caplog) == snapshot
 
 


### PR DESCRIPTION
## What

`CloudEventBus.subscribe` now accepts plain (synchronous) callables in addition to
coroutine handlers. `publish` invokes each handler and awaits the result only when it
is awaitable.

## Why

Home Assistant core — the main consumer of this bus — uses synchronous `@callback`
handlers as its idiomatic event-handling style. The previous signature required
`Callable[[CloudEvent], Awaitable[None]]` and passed `handler(event)` straight into
`asyncio.gather(...)`, so a synchronous handler returning `None` raised
`TypeError: An asyncio.Future, a coroutine or an awaitable is required`. Core therefore
had to wrap every sync handler in an `async def` shim. This change lets it subscribe
those handlers directly.

## Notes

- Additive and backward compatible: existing async handlers behave identically.
- Per-handler error isolation and logging (`gather(..., return_exceptions=True)`) is
  preserved for both sync and async handlers.
- Adds `test_publish_to_sync_handler` covering a plain handler and a `None` return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
