### PR TITLE
Add typed LogoutEvent

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -76,6 +76,7 @@ from .events import (
     LoginEvent,
     LoginFailedEvent,
     LoginFailedReason,
+    LogoutEvent,
 )
 from .exceptions import (
     CloudError,
@@ -169,6 +170,7 @@ __all__ = [
     "LoginEvent",
     "LoginFailedEvent",
     "LoginFailedReason",
+    "LogoutEvent",
     "MFARequired",
     "MigratePaypalAgreementInfo",
     "NabuCasaAuthenticationError",
@@ -622,10 +624,10 @@ class Cloud(Generic[_ClientT]):
     async def logout(self) -> None:
         """Close connection and remove all credentials."""
         self._cancel_pending_auto_login()
-        await self.events.publish(CloudEvent(type=CloudEventType.LOGOUT))
         self.id_token = None
         self.access_token = None
         self.refresh_token = None
+        await self.events.publish(LogoutEvent())
 
         self.started = False
         await self.stop()

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -624,10 +624,14 @@ class Cloud(Generic[_ClientT]):
     async def logout(self) -> None:
         """Close connection and remove all credentials."""
         self._cancel_pending_auto_login()
+
+        # Event is published before tokens are cleared, so subscribers can still access
+        # the tokens if needed
+        await self.events.publish(LogoutEvent())
+
         self.id_token = None
         self.access_token = None
         self.refresh_token = None
-        await self.events.publish(LogoutEvent())
 
         self.started = False
         await self.stop()

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -82,7 +82,7 @@ class CloudClient(ABC):
 
     @abstractmethod
     async def logout_cleanups(self) -> None:
-        """Cleanup on logout (runs last)."""
+        """Cleanup before logout."""
 
     @abstractmethod
     async def async_cloud_connect_update(self, connect: bool) -> None:

--- a/hass_nabucasa/client.py
+++ b/hass_nabucasa/client.py
@@ -82,7 +82,7 @@ class CloudClient(ABC):
 
     @abstractmethod
     async def logout_cleanups(self) -> None:
-        """Cleanup before logout."""
+        """Cleanup on logout (runs last)."""
 
     @abstractmethod
     async def async_cloud_connect_update(self, connect: bool) -> None:

--- a/hass_nabucasa/events/__init__.py
+++ b/hass_nabucasa/events/__init__.py
@@ -9,6 +9,7 @@ from .types import (
     LoginEvent,
     LoginFailedEvent,
     LoginFailedReason,
+    LogoutEvent,
 )
 
 __all__ = [
@@ -21,4 +22,5 @@ __all__ = [
     "LoginEvent",
     "LoginFailedEvent",
     "LoginFailedReason",
+    "LogoutEvent",
 ]

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -95,3 +95,10 @@ class LoginFailedEvent(CloudEvent):
     type: CloudEventType = field(default=CloudEventType.LOGIN_FAILED, init=False)
     reason: LoginFailedReason
     auto: bool = False
+
+
+@dataclass(kw_only=True, frozen=True)
+class LogoutEvent(CloudEvent):
+    """Logout event."""
+
+    type: CloudEventType = field(default=CloudEventType.LOGOUT, init=False)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -230,6 +230,15 @@ async def test_logout_clears_info(cl: cloud.Cloud):
         [cl.iot.disconnect, cl.remote.disconnect, cl.google_report_state.disconnect],
     )
 
+    logout_events: list[cloud.CloudEvent] = []
+    token_at_publish: list[str | None] = []
+
+    async def on_logout(event: cloud.CloudEvent) -> None:
+        logout_events.append(event)
+        token_at_publish.append(cl.id_token)
+
+    cl.events.subscribe(event_type=cloud.CloudEventType.LOGOUT, handler=on_logout)
+
     with patch(
         "hass_nabucasa.Cloud.user_info_path",
         new_callable=PropertyMock(return_value=info_file),
@@ -243,6 +252,11 @@ async def test_logout_clears_info(cl: cloud.Cloud):
     assert cl.access_token is None
     assert cl.refresh_token is None
     assert info_file.unlink.called
+
+    assert len(logout_events) == 1
+    assert isinstance(logout_events[0], cloud.LogoutEvent)
+    assert logout_events[0].type is cloud.CloudEventType.LOGOUT
+    assert token_at_publish == [None]
 
 
 async def test_remove_data(cloud_client: MockClient, cl: cloud.Cloud) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -256,7 +256,7 @@ async def test_logout_clears_info(cl: cloud.Cloud):
     assert len(logout_events) == 1
     assert isinstance(logout_events[0], cloud.LogoutEvent)
     assert logout_events[0].type is cloud.CloudEventType.LOGOUT
-    assert token_at_publish == [None]
+    assert token_at_publish == ["id_token"]
 
 
 async def test_remove_data(cloud_client: MockClient, cl: cloud.Cloud) -> None:


### PR DESCRIPTION
## What

- Add a typed `LogoutEvent(CloudEvent)` dataclass (frozen, `type` defaulted to
  `CloudEventType.LOGOUT` via `init=False`), matching the other typed events, and export
  it from `hass_nabucasa.events` and the top-level `hass_nabucasa` package.
- Publish `LogoutEvent()` from `Cloud.logout()` instead of a bare
  `CloudEvent(type=CloudEventType.LOGOUT)`.

## Why

- **Consistency + typed handling.** LOGOUT was the only event published as a bare
  `CloudEvent`. A dedicated class lets subscribers `isinstance`/annotate/`match` on it,
  keeps the event layer uniform, and can't be constructed with the wrong `type`.

## Notes

- Subscribers to `CloudEventType.LOGOUT` are unaffected — same event type, now a typed
  class.
- The event is still published **before** the tokens are cleared, so a subscriber can
  still read `id_token`/`access_token`/`refresh_token` while handling the logout. A
  comment in `logout()` documents this, and `test_logout_clears_info` asserts the id
  token is still available when the event fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
