### PR TITLE
Harden register-and-auto-login and surface state on the controller

### DIFF
--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -634,7 +634,7 @@ class Cloud(Generic[_ClientT]):
         except CloudError as err:
             _LOGGER.warning("Auto login stopped: %s", err)
             await self._publish_auto_login_failed(
-                controller, LoginFailedReason.AUTH_ERROR
+                controller, LoginFailedReason.CLOUD_ERROR
             )
         except Exception:  # pylint: disable=broad-except
             # Safety net, so an unexpected error never escapes this background task

--- a/hass_nabucasa/__init__.py
+++ b/hass_nabucasa/__init__.py
@@ -217,18 +217,26 @@ class AlreadyConnectedError(CloudError):
         self.details = details
 
 
-@dataclass(frozen=True)
+@dataclass
 class AutoLoginController:
-    """Controls for a pending register-and-auto-login.
+    """Controls and state for a pending register-and-auto-login.
 
     ``cancel`` stops the retry loop; ``attempt_now`` triggers an immediate login
     attempt instead of waiting for the current backoff to elapse; ``resend``
     resends the confirmation email and restarts the retry schedule.
+
+    ``email`` is the (normalized) account being confirmed. ``active`` is ``True``
+    while the retry loop is live and flips to ``False`` on every exit (success,
+    cancel, or give-up). ``failed_reason`` is set only when the loop gives up
+    without logging in, and stays ``None`` on success or cancel.
     """
 
+    email: str
     cancel: Callable[[], None]
     attempt_now: Callable[[], None]
     resend: Callable[[], Awaitable[None]]
+    active: bool = True
+    failed_reason: LoginFailedReason | None = None
 
 
 class Cloud(Generic[_ClientT]):
@@ -489,8 +497,11 @@ class Cloud(Generic[_ClientT]):
             task.cancel()
             self._auto_login_task = None
 
-    async def _publish_auto_login_failed(self, reason: LoginFailedReason) -> None:
+    async def _publish_auto_login_failed(
+        self, controller: AutoLoginController, reason: LoginFailedReason
+    ) -> None:
         """Notify subscribers that auto login gave up without logging in."""
+        controller.failed_reason = reason
         await self.events.publish(LoginFailedEvent(auto=True, reason=reason))
 
     async def register_and_auto_login(
@@ -510,6 +521,11 @@ class Cloud(Generic[_ClientT]):
         an unexpected exception), a LOGIN_FAILED event is published (with auto=True and
         a reason) so the caller can stop waiting.
         """
+        if self.is_logged_in:
+            raise AlreadyLoggedIn(
+                "Cannot register and auto-login while already logged in."
+            )
+
         # Normalize email, so the auto-login uses the same value as the registration
         email = email.lower()
         await self.auth.async_register(email, password, client_metadata=client_metadata)
@@ -517,10 +533,6 @@ class Cloud(Generic[_ClientT]):
         self._cancel_pending_auto_login()
 
         wake = asyncio.Event()
-        task = self._auto_login_task = asyncio.create_task(
-            self._async_auto_login(email, password, wake),
-            name="auto_login",
-        )
 
         def task_active() -> bool:
             """Return True while the retry task is live and not being cancelled."""
@@ -542,12 +554,21 @@ class Cloud(Generic[_ClientT]):
             if task_active():
                 wake.set()
 
-        return AutoLoginController(
-            cancel=cancel, attempt_now=attempt_now, resend=resend
+        controller = AutoLoginController(
+            email=email, cancel=cancel, attempt_now=attempt_now, resend=resend
         )
+        task = self._auto_login_task = asyncio.create_task(
+            self._async_auto_login(email, password, wake, controller),
+            name="auto_login",
+        )
+        return controller
 
     async def _async_auto_login(
-        self, email: str, password: str, wake: asyncio.Event
+        self,
+        email: str,
+        password: str,
+        wake: asyncio.Event,
+        controller: AutoLoginController,
     ) -> None:
         """Retry login until the account is confirmed, then log in."""
         backoff = AUTO_LOGIN_FAST_RETRY_INTERVAL
@@ -597,7 +618,9 @@ class Cloud(Generic[_ClientT]):
                         "Giving up auto login, account was not confirmed within %s",
                         seconds_as_dhms(AUTO_LOGIN_MAX_TOTAL_BACKOFF),
                     )
-                    await self._publish_auto_login_failed(LoginFailedReason.TIMEOUT)
+                    await self._publish_auto_login_failed(
+                        controller, LoginFailedReason.TIMEOUT
+                    )
                     return
 
                 if await wait_for_event(wake, backoff):
@@ -610,12 +633,17 @@ class Cloud(Generic[_ClientT]):
             raise
         except CloudError as err:
             _LOGGER.warning("Auto login stopped: %s", err)
-            await self._publish_auto_login_failed(LoginFailedReason.CLOUD_ERROR)
+            await self._publish_auto_login_failed(
+                controller, LoginFailedReason.AUTH_ERROR
+            )
         except Exception:  # pylint: disable=broad-except
             # Safety net, so an unexpected error never escapes this background task
             _LOGGER.exception("Unexpected error in auto login")
-            await self._publish_auto_login_failed(LoginFailedReason.UNEXPECTED_ERROR)
+            await self._publish_auto_login_failed(
+                controller, LoginFailedReason.UNEXPECTED_ERROR
+            )
         finally:
+            controller.active = False
             if self._auto_login_task is asyncio.current_task():
                 self._auto_login_task = None
 

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -76,7 +76,7 @@ class LoginFailedReason(StrEnum):
     """Reason the register-and-auto-login flow gave up without logging in."""
 
     TIMEOUT = "timeout"
-    CLOUD_ERROR = "cloud_error"
+    AUTH_ERROR = "auth_error"
     UNEXPECTED_ERROR = "unexpected_error"
 
 

--- a/hass_nabucasa/events/types.py
+++ b/hass_nabucasa/events/types.py
@@ -76,7 +76,7 @@ class LoginFailedReason(StrEnum):
     """Reason the register-and-auto-login flow gave up without logging in."""
 
     TIMEOUT = "timeout"
-    AUTH_ERROR = "auth_error"
+    CLOUD_ERROR = "cloud_error"
     UNEXPECTED_ERROR = "unexpected_error"
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -976,8 +976,8 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
-    assert received[0].reason is cloud.LoginFailedReason.AUTH_ERROR
-    assert controller.failed_reason is cloud.LoginFailedReason.AUTH_ERROR
+    assert received[0].reason is cloud.LoginFailedReason.CLOUD_ERROR
+    assert controller.failed_reason is cloud.LoginFailedReason.CLOUD_ERROR
     assert controller.active is False
     assert cl._auto_login_task is None
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -934,7 +934,9 @@ async def test_register_and_auto_login_publishes_failed_event_on_give_up(
     cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
-        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        controller = await cl.register_and_auto_login(
+            "email@home-assistant.io", "password"
+        )
         task = cl._auto_login_task
         assert task is not None
         await task
@@ -943,6 +945,8 @@ async def test_register_and_auto_login_publishes_failed_event_on_give_up(
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
     assert received[0].reason is cloud.LoginFailedReason.TIMEOUT
+    assert controller.failed_reason is cloud.LoginFailedReason.TIMEOUT
+    assert controller.active is False
     assert cl._auto_login_task is None
 
 
@@ -961,7 +965,9 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     cl.events.subscribe(event_type=cloud.CloudEventType.LOGIN_FAILED, handler=on_failed)
 
     with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
-        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        controller = await cl.register_and_auto_login(
+            "email@home-assistant.io", "password"
+        )
         task = cl._auto_login_task
         assert task is not None
         await task
@@ -970,7 +976,9 @@ async def test_register_and_auto_login_publishes_failed_event_on_fatal_error(
     assert len(received) == 1
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
-    assert received[0].reason is cloud.LoginFailedReason.CLOUD_ERROR
+    assert received[0].reason is cloud.LoginFailedReason.AUTH_ERROR
+    assert controller.failed_reason is cloud.LoginFailedReason.AUTH_ERROR
+    assert controller.active is False
     assert cl._auto_login_task is None
 
 
@@ -993,7 +1001,9 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
         caplog.at_level(logging.ERROR),
         patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)),
     ):
-        await cl.register_and_auto_login("email@home-assistant.io", "password")
+        controller = await cl.register_and_auto_login(
+            "email@home-assistant.io", "password"
+        )
         task = cl._auto_login_task
         assert task is not None
         await task
@@ -1003,6 +1013,8 @@ async def test_register_and_auto_login_publishes_failed_event_on_unexpected_erro
     assert received[0].type is cloud.CloudEventType.LOGIN_FAILED
     assert received[0].auto is True
     assert received[0].reason is cloud.LoginFailedReason.UNEXPECTED_ERROR
+    assert controller.failed_reason is cloud.LoginFailedReason.UNEXPECTED_ERROR
+    assert controller.active is False
     assert cl._auto_login_task is None
 
 
@@ -1037,6 +1049,8 @@ async def test_register_and_auto_login_no_failed_event_on_cancel(cl: cloud.Cloud
         await task
 
     assert received == []
+    assert controller.active is False
+    assert controller.failed_reason is None
     assert cl._auto_login_task is None
 
 
@@ -1196,3 +1210,35 @@ async def test_auto_login_cancel_guarded_while_cancelling(cl: cloud.Cloud):
 
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+async def test_register_and_auto_login_raises_when_already_logged_in(cl: cloud.Cloud):
+    """Test registering while already logged in raises before registering."""
+    cl.id_token = "already-logged-in"
+    assert cl.is_logged_in
+    cl.auth.async_register = AsyncMock()
+
+    with pytest.raises(cloud.AlreadyLoggedIn):
+        await cl.register_and_auto_login("email@home-assistant.io", "password")
+
+    cl.auth.async_register.assert_not_called()
+    assert cl._auto_login_task is None
+
+
+async def test_auto_login_controller_reports_email_and_completes(cl: cloud.Cloud):
+    """Test the controller exposes the email and clears state on a clean login."""
+    cl.auth.async_register = AsyncMock()
+    cl.login = AsyncMock(return_value=None)
+
+    with patch("hass_nabucasa.wait_for_event", AsyncMock(return_value=False)):
+        controller = await cl.register_and_auto_login(
+            "Email@Home-Assistant.io", "password"
+        )
+        task = cl._auto_login_task
+        assert task is not None
+        await task
+
+    assert controller.email == "email@home-assistant.io"
+    assert controller.active is False
+    assert controller.failed_reason is None
+    assert cl._auto_login_task is None


### PR DESCRIPTION
## What

Three small, mostly-additive improvements to `Cloud.register_and_auto_login` (added in
#1173 / #1181), so Home Assistant core can lean on the library instead of re-implementing
guards and state on its side. None change the agreed public shape (one method returning
one controller).

- **Entry guard.** `register_and_auto_login` now raises `AlreadyLoggedIn` *before*
  registering if already logged in, instead of registering a real account and then
  silently exiting the retry loop with no event. Core already guards this, so nothing it
  observes changes. The inner `except AlreadyLoggedIn` race guard is kept — it is still
  valid if a concurrent manual login wins while the task is running.
- **Controller carries its own state.** `AutoLoginController` gains `email`, `active`
  (`True` while the retry loop is live; flips to `False` on every exit — success, cancel,
  or give-up), and `failed_reason` (set only on give-up paths, stays `None` on
  success/cancel). Callers can read this instead of mirroring it via event handlers. The
  existing `cancel` / `attempt_now` / `resend` controls are unchanged.
## Tests

- `register_and_auto_login` raises `AlreadyLoggedIn` when already logged in, without
  calling `async_register`.
- The controller exposes `email`, flips `active` to `False` on completion and on cancel,
  and sets `failed_reason` only on the give-up paths (timeout / auth / unexpected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
