### PR TITLE
Key event bus subscribers by CloudEventType

### DIFF
--- a/hass_nabucasa/events/bus.py
+++ b/hass_nabucasa/events/bus.py
@@ -24,9 +24,9 @@ class CloudEventBus:
     def __init__(self) -> None:
         """Initialize the event bus."""
         self._subscribers: dict[
-            str,
+            CloudEventType,
             list[Callable[[CloudEvent], Awaitable[None] | None]],
-        ] = {k.value: [] for k in CloudEventType}
+        ] = {k: [] for k in CloudEventType}
 
     def subscribe(
         self,
@@ -80,7 +80,7 @@ class CloudEventBus:
                 await result
 
         results = await asyncio.gather(
-            *[_invoke(handler) for handler in handlers],
+            *(_invoke(handler) for handler in handlers),
             return_exceptions=True,
         )
 


### PR DESCRIPTION
## Summary

Addresses two review comments on `hass_nabucasa/events/bus.py`:

- **Key `_subscribers` by `CloudEventType`.** The dict was typed as `dict[str, ...]` but every access uses `CloudEventType` values (via `event.type` and the `subscribe` API). It only worked because `CloudEventType` is a `StrEnum`, which made the type misleading and easier to misuse. The dict is now keyed by `CloudEventType` directly and initialized with `{k: [] for k in CloudEventType}`.
- **Use a generator expression in `asyncio.gather`.** Swapped the intermediate list comprehension for a generator expression to avoid the extra allocation. Behavior is identical — `zip(handlers, results, strict=True)` still lines up because `gather` preserves order.

## Testing

- `mypy hass_nabucasa/events/bus.py` — no issues
- `python -m pytest tests/events/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)